### PR TITLE
fix unwritable stream error after disconnected

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -756,7 +756,13 @@ Client.prototype.connect = function ( retryCount ) { // {{{
         buffer = lines.pop();
         lines.forEach(function (line) {
             var message = parseMessage(line);
-            self.emit('raw', message);
+            try {
+                self.emit('raw', message);
+            } catch ( err ) {
+                if ( !self.conn.requestedDisconnect ) {
+                    throw err;
+                }
+            }
         });
     });
     self.conn.addListener("end", function() {


### PR DESCRIPTION
Hi, I'm sublee of Lunant team.

We're making an IRC bot using node-irc development version. You know that the development version implemented the `Client.prototype.disconnect()` method. But when I call this method, some exception was thrown because the IRC server(irc.ozinger.org:6667) sent a message after connection was quitted. I fixed this problem and I want you to accept my pull request.
