### PR TITLE
Properly handle changing user mode

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -562,6 +562,26 @@ function Client(server, nick, opt) {
             case "MODE":
                 if ( self.opt.debug )
                     sys.log("MODE:" + message.args[0] + " sets mode: " + message.args[1]);
+                // properly handle mode changes for users
+                if ( message.args.length >= 3 ) {
+                    var channel = self.chans[message.args[0]],
+                        nicklist_offset = 2,
+                        mode = message.args[1].split(''),
+                        adding = mode.shift() === "+";
+                    for (var i = 0; i < mode.length; i++) {
+                        if (mode[i] == 'o') {
+                            if (adding)
+                                channel.users[message.args[nicklist_offset+i]] = '@';
+                            else
+                                channel.users[message.args[nicklist_offset+i]] = '';
+                        } else if (mode[i] == 'v') {
+                            if (adding)
+                                channel.users[message.args[nicklist_offset+i]] = '+';
+                            else
+                                channel.users[message.args[nicklist_offset+i]] = '';
+                        }
+                    }
+                    }
                 break;
             case "rpl_motdstart":
                 self.motd = message.args[1] + "\n";


### PR DESCRIPTION
There was no hooking into mode changes for dealing with changes in ops and such.

There is still a case which this code doesn't handle. I wasn't sure what you thought. If I +o (op) someone, then +v (voice) them, then -o them.. they're still voiced. It seems to me the best way to do this would be some sort of sorted list, but that seems a bit heavy. Perhaps a string of '@+' which, is altered on mode change? Seems like it would make the code heavier. This at least solves my use case (detecting op/deop). Will happily change the patch if you have other preferences.
