### PR TITLE
Add an event for `/invite`

### DIFF
--- a/API.md
+++ b/API.md
@@ -134,6 +134,12 @@ As per 'message' event but only emits when the message is direct to the client
 
 Emitted when a user changes nick along with the channels the user is in.
 
+### Event: 'invite'
+
+`function (channel, from) { }`
+
+Emitted when the client recieves an `/invite`.
+
 ### Event: 'raw'
 
 `function (message) { }`

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -504,7 +504,7 @@ function Client(server, nick, opt) {
         nick: nick,
         password: null,
         userName: 'nodebot',
-        realName: 'nodeJS IRC client', 
+        realName: 'nodeJS IRC client',
         port: 6667,
         debug: false,
         showErrors: false,
@@ -730,6 +730,12 @@ function Client(server, nick, opt) {
                 if ( self.opt.debug && to == self.nick )
                     sys.log('GOT MESSAGE from ' + from + ': ' + text);
                 break;
+            case "INVITE":
+                var from = message.nick;
+                var to   = message.args[0];
+                var channel = message.args[1];
+                self.emit('invite', channel, from);
+                break;
             case "QUIT":
                 if ( self.opt.debug )
                     sys.log("QUIT: " + message.prefix + " " + message.args.join(" "));
@@ -864,7 +870,7 @@ Client.prototype.disconnect = function ( message ) { // {{{
         self.send( "QUIT", message );
     }
     self.conn.requestedDisconnect = true;
-    self.conn.end();    
+    self.conn.end();
 }; // }}}
 Client.prototype.send = function(command) { // {{{
     var args = [];
@@ -908,7 +914,7 @@ Client.prototype.say = function(target, text) { // {{{
 
 /*
  * parseMessage(line)
- * 
+ *
  * takes a raw "line" from the IRC server and turns it into an object with
  * useful keys
  */


### PR DESCRIPTION
Emits an `invite` event when the client receives an `/invite` from the server. (The raw command is `INVITE`.)
