### PR TITLE
Bug fix in join/part/kick events

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -680,12 +680,12 @@ function Client(server, nick, opt) {
                 self.emit('join', message.args[0], message.nick);
                 self.emit('join' + message.args[0], message.nick);
                 if ( self.nick == message.nick ) {
-                    self.chans[message.args[0]] = {
+                    self.chans[message.args[0].toLowerCase()] = {
                         users: {},
                     };
                 }
                 else {
-                    var channel = self.chans[message.args[0]];
+                    var channel = self.chans[message.args[0].toLowerCase()];
                     channel.users[message.nick] = '';
                 }
                 break;
@@ -694,10 +694,10 @@ function Client(server, nick, opt) {
                 self.emit('part', message.args[0], message.nick, message.args[1]);
                 self.emit('part' + message.args[0], message.nick, message.args[1]);
                 if ( self.nick == message.nick ) {
-                    delete self.chans[message.args[0]];
+                    delete self.chans[message.args[0].toLowerCase()];
                 }
                 else {
-                    var channel = self.chans[message.args[0]];
+                    var channel = self.chans[message.args[0].toLowerCase()];
                     delete channel.users[message.nick];
                 }
                 break;
@@ -707,10 +707,10 @@ function Client(server, nick, opt) {
                 self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2]);
 
                 if ( self.nick == message.args[1] ) {
-                    delete self.chans[message.args[0]];
+                    delete self.chans[message.args[0].toLowerCase()];
                 }
                 else {
-                    var channel = self.chans[message.args[0]];
+                    var channel = self.chans[message.args[0].toLowerCase()];
                     delete channel.users[message.args[1]];
                 }
                 break;


### PR DESCRIPTION
Fixed bug in JOIN/PART/KICK where crash could occur if channel name was different case than expected.

Example: if bot joins IRC channel using the channel name #channel.  It creates a key self.chans["#channel"].users = {}.  Since channel names are case insensitive, in some cases people joining the channel may join with #Channel, #ChAnNeL, or some other variation.  Many IRCDs do not change the channel name to be consistent when broadcasting the event so the bot running irc lib will receive the irc event as :nickname JOIN :#Channel.  This will cause an error during join because it looks at self.chans["#Channel"].users for the nicklist which doesn't exist.

To solve this issue all channels names are forced to lower case with message.args[0].toLowerCase() in JOIN/PART/KICK parsing.  I only noticed this bug in the JOIN event but it is conceivably possible in the other two as well so I went ahead and modified the code there as well.  There may be other places this could be an issue but I tried to get the events where I could foresee it being an issue.
