### PR TITLE
listen for the socket 'close' event rather than 'end'.  'end' is triggere

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -854,6 +854,12 @@ Client.prototype.connect = function ( retryCount ) { // {{{
         });
     });
     self.conn.addListener("end", function() {
+        if ( self.opt.debug )
+            util.log('Connection got "end" event');
+    });
+    self.conn.addListener("close", function() {
+        if ( self.opt.debug )
+            util.log('Connection got "close" event');
         if ( self.conn.requestedDisconnect )
             return;
         if ( self.opt.debug )


### PR DESCRIPTION
listen for the socket 'close' event rather than 'end'.  'end' is triggered when a packet is recieved for the server, so only is emitted in a subset of the possible cases of network interruption.  If the network connection goes down abruptly, for instance, you'll never detect interruption in the client.
