### PR TITLE
Reconnect all rooms upon server reconnect.  

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -898,14 +898,20 @@ Client.prototype.send = function(command) { // {{{
     this.conn.write(command + " " + args.join(" ") + "\r\n");
 }; // }}}
 Client.prototype.join = function(channel, callback) { // {{{
-    if ( typeof(callback) == 'function' ) {
-        var callbackWrapper = function () {
-            this.removeListener('join' + channel, callbackWrapper);
-            return callback.apply(this, arguments);
-        };
-        this.addListener('join' + channel, callbackWrapper);
-    }
+    var callbackWrapper = function () {
+        this.removeListener('join' + channel, callbackWrapper);
+        // if join is successful, add this channel to opts.channels
+        // so that it will be re-joined upon reconnect (as channels
+        // specified in options are)
+        if (this.opt.channels.indexOf(channel) == -1) {
+            this.opt.channels.push(channel);
+        }
 
+        if ( typeof(callback) == 'function' ) {
+            return callback.apply(this, arguments);
+        }
+    };
+    this.addListener('join' + channel, callbackWrapper);
     this.send('JOIN', channel);
 } // }}}
 Client.prototype.part = function(channel, callback) { // {{{
@@ -915,6 +921,12 @@ Client.prototype.part = function(channel, callback) { // {{{
             return callback.apply(this, arguments);
         };
         this.addListener('part' + channel, callbackWrapper);
+    }
+
+    // remove this channel from this.opt.channels so we won't rejoin
+    // upon reconnect
+    if (this.opt.channels.indexOf(channel) != -1) {
+        this.opt.channels.splice(this.opt.channels.indexOf(channel), 1);
     }
 
     this.send('PART', channel);


### PR DESCRIPTION
Reconnect all rooms upon server reconnect.  This patch solves the problem where the library will not reconnect to rooms which were joined using the .join() member (rather than specified in the options parameter at library allocation time).
