### PR TITLE
Parsing out ~ & and % in the channel user list

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -627,7 +627,7 @@ function Client(server, nick, opt) {
                 var channel = self.chans[message.args[2]];
                 var users = message.args[3].split(/ +/);
                 users.forEach(function (user) {
-                    var match = user.match(/^([@+])?(.*)$/);
+                    var match = user.match(/^([@+%~\&])?(.*)$/);
                     if ( !match[1] )
                         match[1] = "";
                     channel.users[match[2]] = match[1];


### PR DESCRIPTION
changed rpl_namreply to pull out chars for halfop, admin and owners (~, & and %)
