### PR TITLE
Update nick after connecting

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -535,6 +535,7 @@ function Client(server, nick, opt) {
     self.addListener("raw", function (message) { // {{{
         switch ( message.command ) {
             case "001":
+						    self.nick = message.args[0];
                 self.emit('registered');
                 break;
             case "002":


### PR DESCRIPTION
In some instances the ircd will change your nick when you connect.  If this happens self.nick was not being updated and causing issues.

e.g. EFNets max nick length is 9.  If you set your nick to "omgthisisalongnick" it will automatically be shortened to "omgthisis".
