### PR TITLE
Fixed bug when sending empty strings or several lines to say

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -932,7 +932,7 @@ Client.prototype.part = function(channel, callback) { // {{{
 Client.prototype.say = function(target, text) { // {{{
     var self = this;
     if (typeof text !== 'undefined') {
-        text.toString().split(/\n|\r/).filter(function(line) {
+        text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;
         }).forEach(function(line) {
             self.send('PRIVMSG', target, line);


### PR DESCRIPTION
This will in theory make it possible to send several lines and empty lines to say, like this:

```
client.say('#test', '');
```

and 

```
client.say('#test', 'Hello!\nworld');
```

Note that it is not widely tested
