### PR TITLE
Adds 'selfMessage' event

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -963,6 +963,7 @@ Client.prototype.part = function(channel, callback) { // {{{
 } // }}}
 Client.prototype.say = function(target, text) { // {{{
     this.send('PRIVMSG', target, text);
+    this.emit('selfMessage', target, text);
 } // }}}
 Client.prototype.notice = function(target, text) { // {{{
     this.send('NOTICE', target, text);


### PR DESCRIPTION
This patch adds a 'selfMessage' event, emitted when a message is sent by the library.  

```
 client.emit('selfMessage', to, text)
```

is the syntax.

Thanks again for the great IRC library!
