### PR TITLE
Handling connection errors

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -886,7 +886,8 @@ Client.prototype.connect = function ( retryCount ) { // {{{
                 self.emit('raw', message);
             } catch ( err ) {
                 if ( !self.conn.requestedDisconnect ) {
-                    throw err;
+                  if ( self.opt.debug ) 
+                    util.log('GOT PARSING ERROR on line ' + line + ' while parsing message ' + message);
                 }
             }
         });
@@ -917,6 +918,12 @@ Client.prototype.connect = function ( retryCount ) { // {{{
             self.connect( retryCount + 1 );
         }, self.opt.retryDelay );
     });
+    self.conn.addListener("error", function (error) {
+      if ( self.opt.debug ) 
+          util.log('GOT CONNECTION ERROR of ' + error + ' on server: ' + self.opt.server);
+    });
+    
+    
 }; // }}}
 Client.prototype.disconnect = function ( message ) { // {{{
     message = message || "node-irc says goodbye";


### PR DESCRIPTION
Hi,

I've been working with your module for the last couple of days and enjoyed the module ease of use.

A critical issue appeared though while I was using it if the IRC server that is given as a parameter to the client constructor is down, then the network connection fails and since the module didn't set a handler to the connection  'error' event, this caused the lib and the application to crash.

A similar scenario happened when trying to send private messages to a non existing user (e.g in the case that user disconnected), but this was caused because the error handler propagated the error by throwing an exception from inside of the connection 'data' event handler (making it impossible to catch this exception by the app).

The changes just wrap these errors with dummy handlers that log the error if debug mode is enabled.

Thank you again for you work,

Cheers!
