### PR TITLE
Channel password support

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -817,7 +817,7 @@ function Client(server, nick, opt) {
     });
     self.addListener('motd', function (motd) {
         self.opt.channels.forEach(function(channel) {
-            self.send('JOIN', channel);
+            self.send.apply(['JOIN'].concat(channel.split(' ')));
         });
     });
 


### PR DESCRIPTION
This tiny patch adds channel password support. Should work with more sophisticated irc servers with additional parameters to `JOIN` as well.
