### PR TITLE
flood protection timeout configurable, another socket message to ignore for self signed certificates

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -60,7 +60,7 @@ function Client(server, nick, opt) {
     }
 
     if (self.opt.floodProtection) {
-        self.activateFloodProtection();
+        self.activateFloodProtection(self.opt.floodProtectionTimeout);
     }
 
     // TODO - fail if nick or server missing
@@ -581,10 +581,10 @@ Client.prototype.send = function(command) { // {{{
         this.conn.write(command + " " + args.join(" ") + "\r\n");
     }
 }; // }}}
-Client.prototype.activateFloodProtection = function() { // {{{
+Client.prototype.activateFloodProtection = function(interval) { // {{{
 
     var cmdQueue = [],
-        safeInterval = self.opt.floodProtectionTimeout || 1000,
+        safeInterval = interval || 1000,
         self = this,
         origSend = this.send,
         dequeue;


### PR DESCRIPTION
fixed self signed certificate problem, made floodProtection timeout configurable and put some more safeties around when joining an empty channel
