### PR TITLE
Update rpl_namreply to ignore empty string users in user list

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -199,12 +199,14 @@ function Client(server, nick, opt) {
                 var users = message.args[3].trim().split(/ +/);
                 if ( channel ) {
                     users.forEach(function (user) {
-                        var match = user.match(/^(.)(.*)$/);
-                        if ( match[1] in self.modeForPrefix ) {
-                            channel.users[match[2]] = match[1];
-                        }
-                        else {
-                            channel.users[match[1] + match[2]] = '';
+                        if(user != '') {
+                            var match = user.match(/^(.)(.*)$/);
+                            if ( match[1] in self.modeForPrefix ) {
+                                channel.users[match[2]] = match[1];
+                            }
+                            else {
+                                channel.users[match[1] + match[2]] = '';
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
rpl_namreply function was not handling a case where the users list could contain a empty string user. This behavior appears on a custom irc server (unreal).
