### PR TITLE
Emit 'message#' for a channel message

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -235,6 +235,13 @@ Events
     this clients nick and means a private message), or a channel (which means a
     message to that channel). See the `raw` event for details on the `message` object.
 
+.. js:data:: 'message#'
+
+    `function (nick, to, text, message) { }`
+
+    Emitted when a message is sent to a channel.
+    See the `raw` event for details on the `message` object.
+
 .. js:data:: 'message#channel'
 
     `function (nick, text, message) { }`

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -360,6 +360,7 @@ function Client(server, nick, opt) {
                 var text = message.args[1];
                 self.emit('message', from, to, text, message);
                 if ( to.match(/^[&#]/) ) {
+                    self.emit('message#', from, to, text, message);
                     self.emit('message' + to, from, text, message);
                     if ( to != to.toLowerCase() ) {
                         self.emit('message' + to.toLowerCase(), from, text, message);


### PR DESCRIPTION
'message' is emitted for both a channel message and a pm.  When listening for 'message' I have to do a check to see if it's from a channel or if it's a pm (In my case I can't really use the 'message#channel' event).  This can be done by checking if the 'to' argument starts with # but as that check is already done in the library, it's simpler to just add another emit.
