### PR TITLE
Fix problem with 'QUIT' command

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -717,7 +717,7 @@ function parseMessage(line, stripColors) { // {{{
     }
 
     // Parse command
-    match = line.match(/^([^ ]+) +/);
+    match = line.match(/^([^ ]+) */);
     message.command = match[1];
     message.rawCommand = match[1];
     message.commandType = 'normal';


### PR DESCRIPTION
Some clients, like Konversation and Quassel, send a 'QUIT' command
when the user closes the client, with no whitespace at the end.

This should fix #64.
