### PR TITLE
Include channels user was in when 'kill' is emitted

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -222,9 +222,11 @@ Events
 
 .. js:data:: 'kill'
 
-    `function (nick, reason, message) { }`
+    `function (nick, reason, channels, message) { }`
 
     Emitted when a user is killed from the IRC server.
+    `channels` is an array of channels the killed user was in which
+    are known to the client.
     See the `raw` event for details on the `message` object.
 
 .. js:data:: 'message'

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -349,10 +349,14 @@ function Client(server, nick, opt) {
                 break;
             case "KILL":
                 var nick = message.args[0];
-                self.emit('kill', nick, message.args[1], message);
+                var channels = [];
                 for ( var channel in self.chans ) {
+                    if ( self.chans[channel].users[nick])
+                        channels.push(channel);
+
                     delete self.chans[channel].users[nick];
                 }
+                self.emit('kill', nick, message.args[1], channels, message);
                 break;
             case "PRIVMSG":
                 var from = message.nick;


### PR DESCRIPTION
Implements #69

Would prompt a version change as the signature of the emit is changed.
