### PR TITLE
add SELF_SIGNED_CERT_IN_CHAIN to the list of excepted authorizationError

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -487,8 +487,10 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
            self.conn.connected = true;
            if (self.conn.authorized ||
                (self.opt.selfSigned &&
-                (self.conn.authorizationError === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
-                self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'))) {
+                (['DEPTH_ZERO_SELF_SIGNED_CERT',
+                  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+                  'SELF_SIGNED_CERT_IN_CHAIN']
+                  .indexOf(self.conn.authorizationError) > -1))) {
               // authorization successful
               self.conn.setEncoding('utf-8');
 


### PR DESCRIPTION
OFTC uses a certificate chain signed by SPI, to allow this to work without passing the CA SELF_SIGNED_CERT_IN_CHAIN needs to also be excepted.
