### PR TITLE
Ignore expired cert with opt.selfSigned

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -488,7 +488,8 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
            if (self.conn.authorized ||
                (self.opt.selfSigned &&
                 (self.conn.authorizationError === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
-                self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'))) {
+                self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+				self.conn.authorizationError === 'CERT_HAS_EXPIRED'))) {
               // authorization successful
               self.conn.setEncoding('utf-8');
 


### PR DESCRIPTION
I see there's a similar pull request, although it seems stalled (https://github.com/martynsmith/node-irc/pull/53). That patch adds a new option, but it feels appropriate to me to have this in the list of ignored errors for the selfSigned option.

Thanks
