### PR TITLE
encoding support

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -48,7 +48,10 @@ function Client(server, nick, opt) {
         certExpired: false,
         floodProtection: false,
         floodProtectionDelay: 1000,
-        stripColors: false
+        stripColors: false,
+        // anything acceptable to iconv: 'ASCII', 'CP1251//IGNORE', etc
+        // false == don't do any
+        encoding: false, 
     };
 
     if (typeof arguments[2] == 'object') {
@@ -62,6 +65,18 @@ function Client(server, nick, opt) {
 
     if (self.opt.floodProtection) {
         self.activateFloodProtection();
+    }
+
+    if (self.opt.encoding) {
+        var Iconv = require('iconv').Iconv;
+        var from = new Iconv(self.opt.encoding, 'UTF-8');
+        var to = new Iconv('UTF-8', self.opt.encoding);
+        self.encode = function(str) {
+            return to.convert(str);
+        }
+        self.decode = function(str) {
+            return from.convert(str);
+        }
     }
 
     // TODO - fail if nick or server missing
@@ -501,7 +516,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
                 (self.opt.certExpired &&
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED')) {
               // authorization successful
-              self.conn.setEncoding('utf-8');
+              if (!self.opt.encoding) self.conn.setEncoding('utf-8');
                 if ( self.opt.certExpired &&
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED' ) {
                      util.log('Connecting to server with expired certificate');
@@ -524,7 +539,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     }
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(0);
-    self.conn.setEncoding('utf8');
+    if (!self.opt.encoding) self.conn.setEncoding('utf-8');
     self.conn.addListener("connect", function () {
         if ( self.opt.password !==  null ) {
             self.send( "PASS", self.opt.password );
@@ -536,7 +551,8 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     });
     var buffer = '';
     self.conn.addListener("data", function (chunk) {
-        buffer += chunk;
+        // it's source of bugs if original encoding is multibyte and message is large
+        buffer += self.decode(chunk);
         var lines = buffer.split("\r\n");
         buffer = lines.pop();
         lines.forEach(function (line) {
@@ -609,7 +625,7 @@ Client.prototype.send = function(command) { // {{{
         util.log('SEND: ' + command + " " + args.join(" "));
 
     if ( ! this.conn.requestedDisconnect ) {
-        this.conn.write(command + " " + args.join(" ") + "\r\n");
+        this.conn.write(this.encode(command + " " + args.join(" ") + "\r\n"));
     }
 }; // }}}
 Client.prototype.activateFloodProtection = function(interval) { // {{{
@@ -690,6 +706,12 @@ Client.prototype.action = function(channel, text) { // {{{
 } // }}}
 Client.prototype.notice = function(target, text) { // {{{
     this.send('NOTICE', target, text);
+} // }}}
+Client.prototype.encode = function(str) { // {{{
+    return str;
+} // }}}
+Client.prototype.decode = function(str) { // {{{
+    return str;
 } // }}}
 Client.prototype.whois = function(nick, callback) { // {{{
     if ( typeof callback === 'function' ) {


### PR DESCRIPTION
Some silly irc servers doesnt support UTF-8 but other encodings (cp1251 in my case). So it would be nice to add support for them.

Currently node-irc works with utf8 only and there is no way to use another encoding here.
