### PR TITLE
Made parseMessage more robust, allow sending of commands without arguments.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -157,7 +157,8 @@ function Client(server, nick, opt) {
                             channel.users[user] = channel.users[user].replace(self.prefixForMode[mode], '');
                             self.emit('-mode', message.args[0], message.nick, mode, user, message);
                           } catch (err) {
-                            console.log('could not modify mode of user: '+user);
+                            if ( self.opt.debug )
+                                util.log('Could not modify mode: ' + user);
                           }
                         }
                     }


### PR DESCRIPTION
Was seeing quite a few regex errors with parseMessage. This should improve performance a bit. I haven't seen any errors since integrating this with my project. Also modified the send method to accept 0 arguments for cases such as /away to remove an away message.
