### PR TITLE
Support non-ASCII nick, username

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -754,7 +754,7 @@ function parseMessage(line, stripColors) { // {{{
     if ( match = line.match(/^:([^ ]+) +/) ) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        if ( match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
+        if ( match = message.prefix.match(/(.*?)!(.*?)@(.*?)/) ) {
             message.nick = match[1];
             message.user = match[3];
             message.host = match[4];


### PR DESCRIPTION
node-irc doesn't support non-ASCII nick, user. So node-irc return undefined nick.
I fix that problem.
