### PR TITLE
Add option to split long messages into multiple PRIVMSG calls

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -29,6 +29,7 @@ Client
             certExpired: false,
             floodProtection: false,
             floodProtectionDelay: 1000,
+            messageSplit: 400,
             stripColors: false
         }
 
@@ -44,6 +45,9 @@ Client
 
     `floodProtectionDelay` sets the amount of time that the client will wait
     between sending subsequent messages when `floodProtection` is enabled.
+
+    `messageSplit` will split up large messages sent with the `say` method
+    into multiple messages of length less than `messageSplit` characters.
 
     `stripColors` removes mirc colors (0x03 followed by one or two ascii
     numbers for foreground,background) and ircII "effect" codes (0x02

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -48,6 +48,7 @@ function Client(server, nick, opt) {
         certExpired: false,
         floodProtection: false,
         floodProtectionDelay: 1000,
+        messageSplit: 400,
         stripColors: false
     };
 
@@ -674,8 +675,11 @@ Client.prototype.say = function(target, text) { // {{{
         text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;
         }).forEach(function(line) {
-            self.send('PRIVMSG', target, line);
-            self.emit('selfMessage', target, line);
+            var r = new RegExp(".{1," + self.opt.messageSplit + "}", "g");
+            while ((messagePart = r.exec(line)) != null) {
+                self.send('PRIVMSG', target, messagePart);
+                self.emit('selfMessage', target, messagePart);
+            }
         });
     }
 } // }}}


### PR DESCRIPTION
Many IRC servers only allow a PRIVMESSAGE length of some number of
characters. This lets the user specify what size they want messages
to be split into.
