### PR TITLE
Don't blow up on 'No such nick/channel' and showErrors before blowing up!

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -37,7 +37,7 @@ function Client(server, nick, opt) {
         realName: 'nodeJS IRC client',
         port: 6667,
         debug: false,
-        showErrors: false,
+        showErrors: true,
         autoRejoin: true,
         autoConnect: true,
         channels: [],
@@ -430,7 +430,19 @@ function Client(server, nick, opt) {
             case "err_nosuchnick":
                 if ( self.opt.showErrors )
                     util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
-                break;    
+                break;  
+            case "err_cannotsendtochan":
+              if ( self.opt.showErrors )
+                  util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
+              break; 
+            case "err_nosuchchannel":
+              if ( self.opt.showErrors )
+                  util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
+              break;
+            case "err_inviteonlychan":
+              if ( self.opt.showErrors )
+                  util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
+              break; 
             default:
                 if ( message.commandType == 'error' ) {
                     if ( self.opt.showErrors )
@@ -787,7 +799,7 @@ function parseMessage(line, stripColors) { // {{{
     if ( line.indexOf(':') != -1 ) {
         match = line.match(/(.*)(?:^:|\s+:)(.*)/);
         middle = match[1].trimRight();
-        trailing = match[2];
+        trailing = match[2]; 
     }
     else {
         middle = line;


### PR DESCRIPTION
- Don't blow up on `err_nosuchnick`, catch it and log it.
- It's a little easier to debug when we throw the pretty errors before blowing up.
