### PR TITLE
Respond to ETIMEDOUT error with a retry

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -577,7 +577,16 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         }, self.opt.retryDelay );
     });
     self.conn.addListener("error", function(exception) {
-        self.emit("netError", exception);
+        util.log('Connection got "error" event with exception: ' + exception);
+        if (exception.message.match(/ETIMEDOUT/)) {
+            util.log("Responding to ETIMEDOUT socket error by disconnecting, reconnecting");
+            self.disconnect('Disconnecting because of socket ETIMEDOUT');
+            setTimeout( function() {
+                self.connect( retryCount + 1 );
+            }, self.opt.retryDelay );
+        } else {
+            self.emit("netError", exception);
+        }
     });
 }; // }}}
 Client.prototype.disconnect = function ( message, callback ) { // {{{


### PR DESCRIPTION
I've been using node-irc over a wireless network. Almost daily, my bot was getting disconnected with an error with the message:

```
Error: read ETIMEDOUT
```

When this happens, node-irc makes no attempt to retry the connection. I've been testing this modification for the past couple of weeks, and this has allowed my bot to reconnect cleanly when this error occurs. 

It seems like this error gets fired before or in place of a close event. I'm not sure if this modification is the cleanest way to deal with this issue, but it seems like the smallest change to do so. There may be an entire class of errors that would benefit from a retry attempt, but I don't know of any others.
