### PR TITLE
Fixed the message splitting on Client.say

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -684,8 +684,8 @@ Client.prototype.say = function(target, text) { // {{{
         }).forEach(function(line) {
             var r = new RegExp(".{1," + self.opt.messageSplit + "}", "g");
             while ((messagePart = r.exec(line)) != null) {
-                self.send('PRIVMSG', target, messagePart);
-                self.emit('selfMessage', target, messagePart);
+                self.send('PRIVMSG', target, messagePart[0]);
+                self.emit('selfMessage', target, messagePart[0]);
             }
         });
     }


### PR DESCRIPTION
`Client.send` expects the parameters to be strings but here `messagePart` is returned by `RegExp.exec` which returns the match object.
