### PR TITLE
Fix for crash when calling whois with non-existant nick

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -786,7 +786,7 @@ Client.prototype.notice = function(target, text) { // {{{
 Client.prototype.whois = function(nick, callback) { // {{{
     if ( typeof callback === 'function' ) {
         var callbackWrapper = function(info) {
-            if ( info.nick == nick ) {
+            if ( typeof info === 'undefined' || info.nick == nick ) {
                 this.removeListener('whois', callbackWrapper);
                 return callback.apply(this, arguments);
             }


### PR DESCRIPTION
Fix for this crash:

/Users/jd/coffee/node_modules/irc/lib/irc.js:548
                    throw err;
                          ^
TypeError: Cannot read property 'nick' of undefined
    at Client.whois.callbackWrapper (/Users/jd/coffee/node_modules/irc/lib/irc.js:697:22)
    at Client.EventEmitter.emit (events.js:88:17)
    at Client.<anonymous> (/Users/jd/coffee/node_modules/irc/lib/irc.js:268:22)
    at Client.EventEmitter.emit (events.js:88:17)
    at Client.connect (/Users/jd/coffee/node_modules/irc/lib/irc.js:545:22)
    at Array.forEach (native)
    at Socket.Client.connect (/Users/jd/coffee/node_modules/irc/lib/irc.js:542:15)
    at Socket.EventEmitter.emit (events.js:88:17)
    at TCP.onread (net.js:392:31)
