### PR TITLE
Fixing ipv6 parsing and messages with colons in them.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -861,7 +861,7 @@ function parseMessage(line, stripColors) { // {{{
     message.command = match[1];
     message.rawCommand = match[1];
     message.commandType = 'normal';
-    line = ' ' + line.replace(/^[^ ]+ +/, '');
+    line = line.replace(/^[^ ]+ +/, '');
 
     if ( replyFor[message.rawCommand] ) {
         message.command     = replyFor[message.rawCommand].name;
@@ -870,10 +870,6 @@ function parseMessage(line, stripColors) { // {{{
 
     message.args = [];
     var middle, trailing;
-
-    if (line.charAt(0) == ':')
-        line = ' ' + line;
-    // Prepare line for parsing
 
     // Parse parameters
     if ( line.indexOf(':') != -1 ) {


### PR DESCRIPTION
As mentioned in https://github.com/martynsmith/node-irc/commit/af75124b18652ea7bbb14b8127fc545404791a32#commitcomment-1956569 this commits breaks messages containing colons anywhere. As you can see in the image below this is parsed using irc.js with that version, it also occasionally crashes on ipv6.

![1cQK5](https://f.cloud.github.com/assets/45660/45178/87bf1cd8-5751-11e2-8c82-8276edb8cf72.png)

I've managed to fix it by checking for a space then a colon, as per the IRC RFC http://www.ietf.org/rfc/rfc1459.txt a colon has to be preceded by a space and as far as I know always is because the command is delimited by spaces. So theres no reason for any fancy regex, we can just force a space in at the start if needed and then look for ' :' because an ipv6 hostname can't contain any spaces.

Please review!
