### PR TITLE
add names for five numerics; fix handling of 002 and 003

### DIFF
--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,4 +1,16 @@
 module.exports = { // {{{
+   "001" : {
+      "name" : "rpl_welcome",
+      "type" : "reply"
+   },
+   "002" : {
+      "name" : "rpl_yourhost",
+      "type" : "reply"
+   },
+   "003" : {
+      "name" : "rpl_created",
+      "type" : "reply"
+   },
    "004" : {
       "name" : "rpl_myinfo",
       "type" : "reply"
@@ -215,12 +227,20 @@ module.exports = { // {{{
       "name" : "rpl_channelmodeis",
       "type" : "reply"
    },
+   "329" : {
+      "name" : "rpl_creationtime",
+      "type" : "reply"
+   },
    "331" : {
       "name" : "rpl_notopic",
       "type" : "reply"
    },
    "332" : {
       "name" : "rpl_topic",
+      "type" : "reply"
+   },
+   "333" : {
+      "name" : "rpl_topicwhotime",
       "type" : "reply"
    },
    "341" : {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -94,15 +94,13 @@ function Client(server, nick, opt) {
 
     self.addListener("raw", function (message) { // {{{
         switch ( message.command ) {
-            case "001":
+            case "rpl_welcome":
                 // Set nick to whatever the server decided it really is
                 // (normally this is because you chose something too long and
                 // the server has shortened it
                 self.nick = message.args[0];
                 self.emit('registered', message);
                 break;
-            case "002":
-            case "003":
             case "rpl_myinfo":
                 self.supported.usermodes = message.args[3];
                 break;
@@ -178,6 +176,8 @@ function Client(server, nick, opt) {
                     }
                 });
                 break;
+            case "rpl_yourhost":
+            case "rpl_created":
             case "rpl_luserclient":
             case "rpl_luserop":
             case "rpl_luserchannels":
@@ -370,8 +370,7 @@ function Client(server, nick, opt) {
             case "rpl_listend":
                 self.emit('channellist', self.channellist);
                 break;
-            case "333":
-                // TODO emit?
+            case "rpl_topicwhotime":
                 var channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.topicBy = message.args[2];
@@ -395,7 +394,7 @@ function Client(server, nick, opt) {
                     channel.mode = message.args[2];
                 }
                 break;
-            case "329":
+            case "rpl_creationtime":
                 var channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.created = message.args[2];


### PR DESCRIPTION
- add names for five numerics (names taken from [RFC 2812 § 5.1](http://tools.ietf.org/html/rfc2812#section-5.1) and [IRC/2 Numeric List](https://www.alien.net.au/irc/irc2numerics.html))
- fix handling of 002 and 003 -- their cases previously fell through to 004's case, now they're properly ignored along with other ignored numerics
