### PR TITLE
Fixed bug with colon inside message

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -873,7 +873,7 @@ function parseMessage(line, stripColors) { // {{{
 
     // Parse parameters
     if ( line.indexOf(':') != -1 ) {
-        match = line.match(/(.*)(?:^:|\s+:)(.*)/);
+        match = line.match(/([^:]+):(.*)/);
         middle = match[1].trimRight();
         trailing = match[2];
     }


### PR DESCRIPTION
When a message contains colons the regexp breaks. It always splits on the last colon instead of the first.
