### PR TITLE
Fixed bug with coilon inside message string

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -873,7 +873,7 @@ function parseMessage(line, stripColors) { // {{{
 
     // Parse parameters
     if ( line.indexOf(':') != -1 ) {
-        match = line.match(/(.*)(?:^:|\s+:)(.*)/);
+        match = line.match(/([^:]*):(.*)/);
         middle = match[1].trimRight();
         trailing = match[2];
     }


### PR DESCRIPTION
If you write e.g. "this is a message with : a colon in it" the resulting string is ":this" because it parses the last colon found, not the first.
