### PR TITLE
Fix for receiving messages with colons

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -872,8 +872,8 @@ function parseMessage(line, stripColors) { // {{{
     var middle, trailing;
 
     // Parse parameters
-    if ( line.indexOf(':') != -1 ) {
-        match = line.match(/(.*)(?:^:|\s+:)(.*)/);
+    if ( line.search(/^:|\s+:/) != -1 ) {
+        match = line.match(/(.*?)(?:^:|\s+:)(.*)/);
         middle = match[1].trimRight();
         trailing = match[2];
     }


### PR DESCRIPTION
This fixes issues #122, #128 and #133.

Example lines include:

```
:some.irc.net 324 webuser #channel +Cnj 5:10
:nick!user@host QUIT :Ping timeout: 252 seconds
:nick!user@host PRIVMSG #channel :so : colons: :are :: not a problem ::::
```
