### PR TITLE
Fix error when nick is null

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -618,8 +618,10 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         if ( self.opt.password !==  null ) {
             self.send( "PASS", self.opt.password );
         }
-        self.send("NICK", self.opt.nick);
-        self.nick = self.opt.nick;
+        if ( self.opt.nick !==  null ) {
+            self.send("NICK", self.opt.nick);
+            self.nick = self.opt.nick;
+        }
         self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
         self.emit("connect");
     });


### PR DESCRIPTION
You are checking if PASS is null but not NICK, I was getting an error on [line 695](https://github.com/jisaacks/node-irc/blob/master/lib/irc.js#L695):

``` javascript
if ( args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === "" ) {
```

The error was:

> TypeError: Cannot call method 'match' of null

Because `self.opt.nick` was null

I just added the same logic to not send nick if it is null.
