### PR TITLE
Fixed crash with janus

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -847,7 +847,7 @@ function parseMessage(line, stripColors) { // {{{
     if ( match = line.match(/^:([^ ]+) +/) ) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        if ( match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
+        if ( match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\\/`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
             message.nick = match[1];
             message.user = match[3];
             message.host = match[4];


### PR DESCRIPTION
In some cases message.nick is undefined when using janus. It appears it can't be parsed properly because janus allows non RFC characters in nicknames to distinguish networks. Such as "X/alpha". This caused a message object to look like:

```
{ line: ':Someone/gig!~quassel@hostname.com JOIN #channel',
  prefix: 'Someone/gig!~quassel@hostname.com JOIN #channel',
  server: 'Someone/gig!~quassel@hostname.com JOIN #channel',
  command: 'JOIN',
  rawCommand: 'JOIN',
  commandType: 'normal',
  args: [ '#channel' ] }
```

This means undefined is passed to events such as join and part, which can cause a crash. I've patched the regex so it can handle parsing nicknames with / in them.

```
{ line: ':Someone/gig!~quassel@hostname.com JOIN #channel',
  prefix: 'Someone/gig!~quassel@hostname.com JOIN #channel',
  nick: 'Someone/gig',
  user: '~quassel',
  host: 'chostname.com',
  command: 'JOIN',
  rawCommand: 'JOIN',
  commandType: 'normal',
  args: [ '#channel' ] }
```

Although it may need to be revised all together as a delimiter can be any character but " !" (I think, struggling to find documentation on it), so in theory a network with any random character could cause a crash. In this scenario `message.prefix.match(/^([^ !]+)(!([^@]+)@(.*))?$/)` would do the job.
