### PR TITLE
Add support for client certificates in connection handling

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -585,8 +585,9 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
            self.conn.connected = true;
            if (self.conn.authorized ||
                 (self.opt.selfSigned &&
-                   (self.conn.authorizationError === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
-                      self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE')) ||
+                   (self.conn.authorizationError   === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
+                      self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+                      self.conn.authorizationError === 'SELF_SIGNED_CERT_IN_CHAIN')) ||
                 (self.opt.certExpired &&
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED')) {
               // authorization successful


### PR DESCRIPTION
The tls object will set a `SELF_SIGNED_CERT_IN_CHAIN` error when using X.509
certificates with a particular host. This has been tested against an IRC server that mandates client certificates.
