### PR TITLE
illegal characters

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -194,6 +194,9 @@ function Client(server, nick, opt) {
                 self.send("NICK", self.opt.nick + self.opt.nickMod);
                 self.nick = self.opt.nick + self.opt.nickMod;
                 break;
+            case "err_erroneusnickname":
+                self.emit('error432', message);
+                break;
             case "PING":
                 self.send("PONG", message.args[0]);
                 self.emit('ping', message.args[0]);


### PR DESCRIPTION
if you choose a name like "123ABC" (ABC123 works fine) or one with illegal characters "åäö" this error message pops up and you can't connect

EDIT: I just realized that addlistener(raw) could show this error too
