### PR TITLE
Fix a crash bug when a zero length message is received

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -204,7 +204,7 @@ function Client(server, nick, opt) {
                 if (!to) {
                     to   = null;
                 }
-                var text = message.args[1];
+                var text = message.args[1] || '';
                 if (text[0] === '\1' && text.lastIndexOf('\1') > 0) {
                     self._handleCTCP(from, to, text, 'notice');
                     break;
@@ -464,7 +464,7 @@ function Client(server, nick, opt) {
             case "PRIVMSG":
                 var from = message.nick;
                 var to   = message.args[0];
-                var text = message.args[1];
+                var text = message.args[1] || '';
                 if (text[0] === '\1' && text.lastIndexOf('\1') > 0) {
                     self._handleCTCP(from, to, text, 'privmsg');
                     break;


### PR DESCRIPTION
Hello.

When a zero-length PRIVMSG / NOTICE message is sent to an channel that a node-irc bot is present in, it crashes with the following backtrace:

```
/home/shiwano/projects/lo_Ol/node_modules/hubot-irc/node_modules/irc/lib/irc.js:637
                    throw err;
                          ^
TypeError: Cannot read property '0' of undefined
  at Client.<anonymous> (/home/shiwano/projects/lo_Ol/node_modules/hubot-irc/node_modules/irc/lib/irc.js:468:25)
  at Client.EventEmitter.emit (events.js:95:17)
  at /home/shiwano/projects/lo_Ol/node_modules/hubot-irc/node_modules/irc/lib/irc.js:634:22
  at Array.forEach (native)
  at CleartextStream.<anonymous> (/home/shiwano/projects/lo_Ol/node_modules/hubot-irc/node_modules/irc/lib/irc.js:631:15)
  at CleartextStream.EventEmitter.emit (events.js:95:17)
  at CleartextStream.<anonymous> (_stream_readable.js:720:14)
  at CleartextStream.EventEmitter.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:392:10)
  at _stream_readable.js:385:7
  at process._tickCallback (node.js:415:13)
```

I fixed it. Could you review it? Thanks.
