### PR TITLE
Fix Cient.join: when user specify a password

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -52,7 +52,7 @@ function Client(server, nick, opt) {
         channelPrefixes: "&#",
         messageSplit: 512
     };
-    
+
     // Features supported by the server
     // (initial values are RFC 1459 defaults. Zeros signify
     // no default or unlimited value)
@@ -123,7 +123,6 @@ function Client(server, nick, opt) {
                                 value = value.split(',');
                                 var type = ['a','b','c','d']
                                 for (var i = 0; i < type.length; i++) {
-                                    
                                     self.supported.channel.modes[type[i]] += value[i];
                                 }
                                 break;
@@ -729,7 +728,8 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
 
 }; // }}}
 Client.prototype.join = function(channel, callback) { // {{{
-    this.once('join' + channel, function () {
+    var channelName =  channel.split(' ')[0];
+    this.once('join' + channelName, function () {
         // if join is successful, add this channel to opts.channels
         // so that it will be re-joined upon reconnect (as channels
         // specified in options are)


### PR DESCRIPTION
Hello,

When you try to join a channel with a password it does work, but doesn't enter the event because of the space "#mychannel mypassword".

I fixed that byt only taking the first element of the string as event name.

Thank you,

Peter
