### PR TITLE
Fix deletion of Array elements

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -277,7 +277,7 @@ function Client(server, nick, opt) {
                     var channel = self.chans[channame];
                     if ( 'string' == typeof channel.users[message.nick] ) {
                         channel.users[message.args[0]] = channel.users[message.nick];
-                        delete channel.users[message.nick];
+                        channel.users.splice(message.nick, 1);
                         channels.push(channame);
                     }
                 }
@@ -426,11 +426,11 @@ function Client(server, nick, opt) {
                 }
                 if ( self.nick == message.nick ) {
                     var channel = self.chanData(message.args[0]);
-                    delete self.chans[channel.key];
+                    self.chans.splice(channel.key, 1);
                 }
                 else {
                     var channel = self.chanData(message.args[0]);
-                    delete channel.users[message.nick];
+                    channel.users.splice(message.nick, 1);
                 }
                 break;
             case "KICK":
@@ -443,11 +443,11 @@ function Client(server, nick, opt) {
 
                 if ( self.nick == message.args[1] ) {
                     var channel = self.chanData(message.args[0]);
-                    delete self.chans[channel.key];
+                    self.chans.splice(channel.key, 1);
                 }
                 else {
                     var channel = self.chanData(message.args[0]);
-                    delete channel.users[message.args[1]];
+                    channel.users.splice(message.args[1], 1);
                 }
                 break;
             case "KILL":
@@ -457,7 +457,7 @@ function Client(server, nick, opt) {
                     if ( self.chans[channel].users[nick])
                         channels.push(channel);
 
-                    delete self.chans[channel].users[nick];
+                    self.chans[channel].users.splice(nick, 1);
                 }
                 self.emit('kill', nick, message.args[1], channels, message);
                 break;
@@ -503,7 +503,7 @@ function Client(server, nick, opt) {
                 for ( var channame in self.chans ) {
                     var channel = self.chans[channame];
                     if ( 'string' == typeof channel.users[message.nick] ) {
-                        delete channel.users[message.nick];
+                        channel.users.splice(message.nick, 1);
                         channels.push(channame);
                     }
                 }
@@ -809,7 +809,7 @@ Client.prototype._clearWhoisData = function(nick) { // {{{
     // Ensure that at least the nick exists before trying to return
     this._addWhoisData(nick, 'nick', nick);
     var data = this._whoisData[nick];
-    delete this._whoisData[nick];
+    this._whoisData.splice(nick, 1);
     return data;
 } // }}}
 Client.prototype._handleCTCP = function(from, to, text, type) {


### PR DESCRIPTION
Node-IRC uses `delete` keyword to remove things from Array which actually sets it to `undefined`. This causes unexpected errors like:

```
/home/ubuntu/scrollback/node_modules/irc/lib/irc.js:637
                    throw err;
                          ^
TypeError: Cannot call method 'replace' of undefined
    at /home/ubuntu/scrollback/node_modules/irc/lib/irc.js:239:71
    at Array.forEach (native)
    at Client.<anonymous> (/home/ubuntu/scrollback/node_modules/irc/lib/irc.js:226:26)
    at Client.EventEmitter.emit (events.js:95:17)
    at /home/ubuntu/scrollback/node_modules/irc/lib/irc.js:634:22
    at Array.forEach (native)
    at Socket.<anonymous> (/home/ubuntu/scrollback/node_modules/irc/lib/irc.js:631:15)
    at Socket.EventEmitter.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:720:14)
    at Socket.EventEmitter.emit (events.js:92:17)
```

This patch fixes this problem.
