### PR TITLE
Ping timeout support

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -36,6 +36,9 @@ function Client(server, nick, opt) {
         userName: 'nodebot',
         realName: 'nodeJS IRC client',
         port: 6667,
+        pingTimeout: 30*1000,
+        pingInterval: 60*1000,
+        hostIdTimeout: 20*1000,
         debug: false,
         showErrors: false,
         autoRejoin: true,
@@ -100,8 +103,24 @@ function Client(server, nick, opt) {
                 // the server has shortened it
                 self.nick = message.args[0];
                 self.emit('registered', message);
+                self.hostIdTimer = setTimeout( function() {
+                    if ( self.opt.debug )
+                        util.log('Server took too long to send 002');
+                    self.conn.emit('timeout');
+                }, self.opt.hostIdTimeout);
                 break;
             case "002":
+                clearTimeout(self.hostIdTimer);
+                self.host = message.args[1].substring(13).split(',')[0];
+                self.pingLoop = setInterval( function() {
+                    self.send('PING', self.host);
+                    clearTimeout(self.pingTimeoutTimer);
+                    self.pingTimeoutTimer = setTimeout(function () {
+                        if ( self.opt.debug )
+                            util.log('Ping timeout');
+                        self.conn.emit('timeout');
+                    }, self.opt.pingTimeout);
+                }, self.opt.pingInterval);
             case "003":
             case "rpl_myinfo":
                 self.supported.usermodes = message.args[3];
@@ -197,6 +216,11 @@ function Client(server, nick, opt) {
             case "PING":
                 self.send("PONG", message.args[0]);
                 self.emit('ping', message.args[0]);
+                break;
+            case "PONG":
+                clearTimeout(self.pingTimeoutTimer);
+                if ( self.opt.debug )
+                    util.log('GOT PONG from '+message.args[0]);
                 break;
             case "NOTICE":
                 var from = message.nick;
@@ -643,7 +667,15 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         if ( self.opt.debug )
             util.log('Connection got "end" event');
     });
+    self.conn.addListener("timeout", function() {
+        if ( self.opt.debug )
+            util.log('Connection got "timeout" event');
+        self.conn.emit('close', true);
+    });
     self.conn.addListener("close", function() {
+        clearInterval(self.pingLoop);
+        clearTimeout(self.pingTimeoutTimer);
+
         if ( self.opt.debug )
             util.log('Connection got "close" event');
         if ( self.conn.requestedDisconnect )


### PR DESCRIPTION
I've added support for ping timeouts, as requested in issue #76. 

It may be worth reviewing the way I am triggering reconnects, since I've seen other pull requests use .disconnect(), although that doesn't seem right to me.
