### PR TITLE
Fix the color wrap function

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -20,8 +20,11 @@ codes = {
 exports.codes = codes;
 
 function wrap(color, text, reset_color) {
-    reset_color = typeof(a) != 'undefined' ? a : 'reset';
-    return codes[color] + text + codes[reset_color];
+    if(codes[color]) {
+        text = codes[color] + text;
+        text += (codes[reset_color]) ? codes[reset_color] : codes['reset'];
+    }
+    return text;
 };
 exports.wrap = wrap;
 


### PR DESCRIPTION
The wrap color function isn't working properly, allowing invalid color names for color and not taking reset_color into account.
This commit forces input validation against the list of color codes: if `color` is an invalid color entry, the function returns only the unmodified text; if `reset_color` is invalid, it is set to 'reset'.
