### PR TITLE
fix(lib/irc): Use protected loops when iterating channels to remove users

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -273,14 +273,12 @@ function Client(server, nick, opt) {
                 var channels = [];
 
                 // TODO better way of finding what channels a user is in?
-                for ( var channame in self.chans ) {
+                Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    if ( 'string' == typeof channel.users[message.nick] ) {
-                        channel.users[message.args[0]] = channel.users[message.nick];
-                        delete channel.users[message.nick];
-                        channels.push(channame);
-                    }
-                }
+                    channel.users[message.args[0]] = channel.users[message.nick];
+                    delete channel.users[message.nick];
+                    channels.push(channame);
+                });
 
                 // old nick, new nick, channels
                 self.emit('nick', message.nick, message.args[0], channels, message);
@@ -452,12 +450,11 @@ function Client(server, nick, opt) {
             case "KILL":
                 var nick = message.args[0];
                 var channels = [];
-                for ( var channel in self.chans ) {
-                    if ( self.chans[channel].users[nick])
-                        channels.push(channel);
-
-                    delete self.chans[channel].users[nick];
-                }
+                Object.keys(self.chans).forEach(function(channame) {
+                    var channel = self.chans[channame];
+                    channels.push(channame);
+                    delete channel.users[nick];
+                });
                 self.emit('kill', nick, message.args[1], channels, message);
                 break;
             case "PRIVMSG":
@@ -499,13 +496,11 @@ function Client(server, nick, opt) {
                 var channels = [];
 
                 // TODO better way of finding what channels a user is in?
-                for ( var channame in self.chans ) {
+                Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    if ( 'string' == typeof channel.users[message.nick] ) {
-                        delete channel.users[message.nick];
-                        channels.push(channame);
-                    }
-                }
+                    delete channel.users[message.nick];
+                    channels.push(channame);
+                });
 
                 // who, reason, channels
                 self.emit('quit', message.nick, message.args[0], channels, message);


### PR DESCRIPTION
Because we are iterating objects, we need to be sure that the property actually exists. Iterating the keys of the object accomplishes this.

Also because we are only iterating what we want, we can drop the type checks.
