### PR TITLE
fixed SASL support

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -615,7 +615,9 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED' ) {
                      util.log('Connecting to server with expired certificate');
                 }
-                if ( self.opt.password !==  null ) {
+                if ( self.opt.sasl ) {
+                    self.send("CAP REQ", "sasl ");
+                } else if ( self.opt.password !==  null ) {
                     self.send( "PASS", self.opt.password );
                 }
                 if ( self.opt.debug )


### PR DESCRIPTION
As of current master, with SASL enabled on an unsecure connection, `CAP REQ ::sasl` is sent. On a secure connection SASL is not used even when specified in the options. This pull request fixed both of these issues by simply sending a `CAP REQ :sasl` on both connection types when `sasl` is set in options.
