### PR TITLE
Fixing the new line bug.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -650,7 +650,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     var buffer = '';
     self.conn.addListener("data", function (chunk) {
         buffer += chunk;
-        var lines = buffer.split("\r\n");
+        var lines = buffer.split("\n");
         buffer = lines.pop();
         lines.forEach(function (line) {
             var message = parseMessage(line, self.opt.stripColors);


### PR DESCRIPTION
I started using this library to connect to bitlbee via irssi proxy.  I found that no events were being emitted after I connected (even though the IRC messages were going back and forth on the socket).  After some debugging I found the culprit that you can see in the diff.  After the change the events emit just fine and I can use the library.

\r seems to be trimmed anyway from the lines so it should be safe and fine to split only by \n.
