### PR TITLE
Fix channellist when list sent without liststart

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -366,9 +366,11 @@ function Client(server, nick, opt) {
                     topic: message.args[3],
                 };
                 self.emit('channellist_item', channel);
+                self.channellist = self.channellist || [];
                 self.channellist.push(channel);
                 break;
             case "rpl_listend":
+                self.channellist = [];
                 self.emit('channellist', self.channellist);
                 break;
             case "rpl_topicwhotime":


### PR DESCRIPTION
This happens on bitlbee:

`rpl_list` is called without `rpl_liststart` causing the method push being called on the undefined variable channellist

Check out: http://code.bitlbee.org/lh/bitlbee/view/998/irc_commands.c#L676

The codes 322 (list) and 323 (listend) are being called properly, but no 321 (liststart).