### PR TITLE
Added support for Ping Timeouts

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -51,7 +51,10 @@ function Client(server, nick, opt) {
         sasl: false,
         stripColors: false,
         channelPrefixes: "&#",
-        messageSplit: 512
+        messageSplit: 512,
+        hostIdTimeout: 90*1000,
+        pingTimeoutLength: 5*1000,
+        pingInterval: 2*1000
     };
 
     // Features supported by the server
@@ -93,6 +96,24 @@ function Client(server, nick, opt) {
       self.connect();
     }
 
+    function sendPing(sendNow) {
+        function doPing() {
+            self.send('PING', self.host);
+            self.pingTimeoutTimer = setTimeout(function(){
+                if (self.opt.debug) {
+                    util.log('Ping timeout');
+                }
+                self.emit('timeout');
+            }, self.opt.pingTimeoutLength);
+        }
+        if (sendNow) {
+            doPing();
+        }
+        else {
+            self.pingTimer = setTimeout(doPing, self.opt.pingInterval);
+        }
+    }
+
     self.addListener("raw", function (message) { // {{{
         switch ( message.command ) {
             case "rpl_welcome":
@@ -101,7 +122,19 @@ function Client(server, nick, opt) {
                 // the server has shortened it
                 self.nick = message.args[0];
                 self.emit('registered', message);
+
+                self.hostIdTimer = setTimeout( function() {
+                    if ( self.opt.debug )
+                        util.log('Server took too long to send 002');
+                    self.emit('timeout');
+                }, self.opt.hostIdTimeout);
                 break;
+            case "rpl_yourhost":
+                clearTimeout(self.hostIdTimer);
+                self.host = message.args[1].substring(13).split(',')[0];
+                sendPing(true);
+                break;
+            case "rpl_created":
             case "rpl_myinfo":
                 self.supported.usermodes = message.args[3];
                 break;
@@ -176,8 +209,6 @@ function Client(server, nick, opt) {
                     }
                 });
                 break;
-            case "rpl_yourhost":
-            case "rpl_created":
             case "rpl_luserclient":
             case "rpl_luserop":
             case "rpl_luserchannels":
@@ -193,6 +224,10 @@ function Client(server, nick, opt) {
                 self.opt.nickMod++;
                 self.send("NICK", self.opt.nick + self.opt.nickMod);
                 self.nick = self.opt.nick + self.opt.nickMod;
+                break;
+            case "PONG":
+                clearTimeout(self.pingTimeoutTimer);
+                sendPing(false);
                 break;
             case "PING":
                 self.send("PONG", message.args[0]);
@@ -558,6 +593,14 @@ function Client(server, nick, opt) {
         });
     });
 
+    self.addListener('timeout', function () {
+        self.conn.wantsReconnect = true;
+        if ( self.opt.debug ) {
+            util.log('timeout');
+        }
+        self.disconnect('Client detected ping timeout');
+    });
+
     process.EventEmitter.call(this);
 }
 
@@ -633,6 +676,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         self.conn = net.createConnection(self.opt.port, self.opt.server);
     }
     self.conn.requestedDisconnect = false;
+    self.conn.wantsReconnect = false;
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
     self.conn.addListener("connect", function () {
@@ -668,9 +712,11 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
             util.log('Connection got "end" event');
     });
     self.conn.addListener("close", function() {
+        clearTimeout(self.pingTimer);
+        clearTimeout(self.hostIdTimer);
         if ( self.opt.debug )
             util.log('Connection got "close" event');
-        if ( self.conn.requestedDisconnect )
+        if ( self.conn.requestedDisconnect && !self.conn.wantsReconnect )
             return;
         if ( self.opt.debug )
             util.log('Disconnected: reconnecting');

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -53,8 +53,8 @@ function Client(server, nick, opt) {
         channelPrefixes: "&#",
         messageSplit: 512,
         hostIdTimeout: 90*1000,
-        pingTimeoutLength: 5*1000,
-        pingInterval: 2*1000
+        pingTimeoutLength: 90*1000,
+        pingInterval: 30*1000
     };
 
     // Features supported by the server


### PR DESCRIPTION
In order to send PINGs, as far as I can tell, we must know the name of our host,
so I've also added a mechanism for accepting the "yourhost" event and storing
the name received, then using that for the pings.

Of course, we might get a timeout after connection and waiting for the "yourhost"
event, so there's a timer there as well.