### PR TITLE
passing through tls options

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -51,7 +51,8 @@ function Client(server, nick, opt) {
         sasl: false,
         stripColors: false,
         channelPrefixes: "&#",
-        messageSplit: 512
+        messageSplit: 512,
+        rejectUnauthorized: true // set to false for self signed certs
     };
 
     // Features supported by the server
@@ -596,7 +597,9 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     if (self.opt.secure) {
         var creds = self.opt.secure;
         if (typeof self.opt.secure !== 'object') {
-            creds = {};
+            creds = {
+                rejectUnauthorized: self.opt.rejectUnauthorized
+            };
         }
 
         self.conn = tls.connect(self.opt.port, self.opt.server, creds, function() {


### PR DESCRIPTION
The addition of this change will allow for underlying TLS module to not error on self signed certificates.
