### PR TITLE
Character encoding autodetection

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -22,7 +22,7 @@ var net  = require('net');
 var tls  = require('tls');
 var util = require('util');
 var charsetDetector = require("node-icu-charset-detector");
-var Iconv = require("iconv").Iconv;
+var iconv = require('iconv-lite');
 
 var colors = require('./colors');
 exports.colors = colors;
@@ -35,8 +35,7 @@ function bufferToString(buffer) {
 	  try {
 	    return buffer.toString(charset);
 	  } catch (x) {
-	    var charsetConverter = new Iconv(charset, "utf8");
-	    return charsetConverter.convert(buffer).toString();
+	    return iconv.decode(buffer, charset);
 	  }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     } ],
     "dependencies": {
         "ansi-color" : "0.2.1",
-        "iconv": "2.0.7",
+        "iconv-lite": "0.2.11",
         "node-icu-charset-detector": "0.0.7"
     },
     "devDependencies": {


### PR DESCRIPTION
node-irc did not handle mixed character encodings very well. It replaced the characters that were not utf-8 with utf-8 replacement characters, thus making it impossible to decode the original content of the message. This commit enables automagical character encoding conversion to utf-8
