### PR TITLE
Fix: callback for 'part'

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -782,6 +782,10 @@ Client.prototype.part = function(channel, message, callback) { // {{{
     if (this.opt.channels.indexOf(channel) != -1) {
         this.opt.channels.splice(this.opt.channels.indexOf(channel), 1);
     }
+
+    if ( typeof(callback) == 'function' ) {
+        return callback.apply(this, arguments);
+    }
     
     if (message) {
 	    this.send('PART', channel, message);


### PR DESCRIPTION
It seems that the callback for 'part' action is ignored.
