### PR TITLE
Fix data split delimiter for backward compatibility

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -689,7 +689,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
     var buffer = '';
     self.conn.addListener('data', function(chunk) {
         buffer += chunk;
-        var lines = buffer.split('\r\n');
+        var lines = buffer.split(/\r\n|\r|\n/);
         buffer = lines.pop();
         lines.forEach(function(line) {
             var message = parseMessage(line, self.opt.stripColors);


### PR DESCRIPTION
IRC Protocol use CR-LF, but legacy IRC server send other code.
http://tools.ietf.org/html/rfc1459.html#section-8

So, replace split string from \r\n with /\r\n|\r|\n/