### PR TITLE
Added CAP identify-message for supported servers an as option

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -51,7 +51,8 @@ function Client(server, nick, opt) {
         sasl: false,
         stripColors: false,
         channelPrefixes: "&#",
-        messageSplit: 512
+        messageSplit: 512,
+        identifyMsg: false
     };
 
     // Features supported by the server
@@ -521,6 +522,9 @@ function Client(server, nick, opt) {
                      message.args[1] === 'ACK' &&
                      message.args[2] === 'sasl ' ) // there's a space after sasl
                     self.send("AUTHENTICATE", "PLAIN");
+                if (opt.identifyMsg){
+                    self.send("CAP", "END");
+                }
                 break;
             case "AUTHENTICATE":
                 if ( message.args[0] === '+' ) self.send("AUTHENTICATE",
@@ -647,6 +651,9 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
     self.conn.addListener("connect", function () {
+        if (opt.identifyMsg){
+            self.send("CAP REQ", "identify-msg");
+        }
         if ( self.opt.sasl ) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send("CAP REQ", "sasl");


### PR DESCRIPTION
Library lacks any kind of real authentication measure -  you can't check if user is registered with nickserv without actually asking nickserv. That takes a while for response, and with extensive amount of querying it wouldn't realy work well. Fix I added doesn't break any current usability by default, but if you enable it you'll be able to get user's authorization status just by checking first message character (- if unathorized, + if authorized).