### PR TITLE
Get SASL working with a separate SASL username field

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -515,9 +515,11 @@ function Client(server, nick, opt) {
 
             // for sasl
             case "CAP":
+              if ( self.opt.debug ) {
                 util.log(message.args[0]+"-")
                 util.log(message.args[1]+"-")
                 util.log(message.args[2]+"-")
+              }
                 if ( //message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
                      message.args[2] === 'sasl' ) { // there's a space after sasl
@@ -533,7 +535,8 @@ function Client(server, nick, opt) {
                       self.opt.saslUserName + '\0' +
                       self.opt.password
                   )
-                  util.log("buf-"+ buf)
+                  if ( self.opt.debug )
+                    util.log("buf-"+ buf)
                   self.send("AUTHENTICATE",buf.toString('base64'));
                 break;
             case "903":
@@ -644,8 +647,12 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
                      util.log('Connecting to server with expired certificate');
                 }
 
+              // set a timer to run a connect event in 5 seconds, since the
+              // SASL nego is event driven
+              //
+              // TODO: this should be a configurable setting
               setTimeout(function() {
-                util.log('Timer fired');
+                util.log('Connect timer fired');
                 self.conn.emit('connect')
                 }, 5000);
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -49,6 +49,7 @@ function Client(server, nick, opt) {
         floodProtection: false,
         floodProtectionDelay: 1000,
         sasl: false,
+        saslUserName: 'nodebot',
         stripColors: false,
         channelPrefixes: "&#",
         messageSplit: 512
@@ -87,13 +88,10 @@ function Client(server, nick, opt) {
         self.activateFloodProtection();
     }
 
-    // TODO - fail if nick or server missing
-    // TODO - fail if username has a space in it
-    if (self.opt.autoConnect === true) {
-      self.connect();
-    }
-
     self.addListener("raw", function (message) { // {{{
+      if ( self.opt.debug )
+          util.log('Message parsed: ' + message.command);
+
         switch ( message.command ) {
             case "rpl_welcome":
                 // Set nick to whatever the server decided it really is
@@ -517,18 +515,26 @@ function Client(server, nick, opt) {
 
             // for sasl
             case "CAP":
-                if ( message.args[0] === '*' &&
+                util.log(message.args[0]+"-")
+                util.log(message.args[1]+"-")
+                util.log(message.args[2]+"-")
+                if ( //message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ' ) // there's a space after sasl
+                     message.args[2] === 'sasl' ) { // there's a space after sasl
+                     self.send("NICK", self.opt.nick);
                     self.send("AUTHENTICATE", "PLAIN");
-                break;
+
+                    break;
+                  }
             case "AUTHENTICATE":
-                if ( message.args[0] === '+' ) self.send("AUTHENTICATE",
-                    new Buffer(
-                        self.opt.nick + '\0' +
-                        self.opt.userName + '\0' +
-                        self.opt.password
-                    ).toString('base64'));
+                if ( message.args[0] === '+' )
+                  var buf = new Buffer(
+                      self.opt.nick + '\0' +
+                      self.opt.saslUserName + '\0' +
+                      self.opt.password
+                  )
+                  util.log("buf-"+ buf)
+                  self.send("AUTHENTICATE",buf.toString('base64'));
                 break;
             case "903":
                 self.send("CAP", "END");
@@ -569,6 +575,14 @@ function Client(server, nick, opt) {
         });
     });
 
+    // TODO - fail if nick or server missing
+    // TODO - fail if username has a space in it
+    if (self.opt.autoConnect === true) {
+      self.connect();
+    }
+
+    if ( self.opt.debug )
+      util.log("process.EventEmitter.call(this)");
     process.EventEmitter.call(this);
 }
 
@@ -610,6 +624,9 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
             creds = {rejectUnauthorized: !self.opt.selfSigned};
         }
 
+        if ( self.opt.debug )
+            util.log('Attempting TLS connect()');
+
         self.conn = tls.connect(self.opt.port, self.opt.server, creds, function() {
            // callback called only after successful socket connection
            self.conn.connected = true;
@@ -626,44 +643,56 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED' ) {
                      util.log('Connecting to server with expired certificate');
                 }
-                if ( self.opt.password !==  null ) {
-                    self.send( "PASS", self.opt.password );
-                }
-                if ( self.opt.debug )
-                    util.log('Sending irc NICK/USER');
-                self.send("NICK", self.opt.nick);
-                self.nick = self.opt.nick;
-                self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
-                self.emit("connect");
+
+              setTimeout(function() {
+                util.log('Timer fired');
+                self.conn.emit('connect')
+                }, 5000);
+
            } else {
               // authorization failed
              util.log(self.conn.authorizationError);
            }
         });
     }else {
+      if ( self.opt.debug )
+          util.log('Attempting insecure connect()');
         self.conn = net.createConnection(self.opt.port, self.opt.server);
+        self.emit('connect')
     }
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
+
+    if ( self.opt.debug )
+        util.log('Connect listener added');
+
     self.conn.addListener("connect", function () {
-        if ( self.opt.sasl ) {
-            // see http://ircv3.atheme.org/extensions/sasl-3.1
-            self.send("CAP REQ", "sasl");
-        } else if ( self.opt.password !==  null ) {
-            self.send( "PASS", self.opt.password );
-        }
+      if ( self.opt.debug )
+          util.log('Connect listener fired');
+
+      if ( self.opt.sasl ) {
+          // see http://ircv3.atheme.org/extensions/sasl-3.1
+          self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
+          self.send("CAP REQ", "sasl");
+      } else if ( self.opt.password !==  null) {
         self.send("NICK", self.opt.nick);
         self.nick = self.opt.nick;
         self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
-        self.emit("connect");
+        self.send( "PASS", self.opt.password );
+      }
     });
+    self.emit("connect");
+
     var buffer = '';
     self.conn.addListener("data", function (chunk) {
         buffer += chunk;
         var lines = buffer.split("\r\n");
         buffer = lines.pop();
         lines.forEach(function (line) {
+            if ( self.opt.debug )
+                util.log('RECV: ' + line);
+
             var message = parseMessage(line, self.opt.stripColors);
             try {
                 self.emit('raw', message);
@@ -674,10 +703,16 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
             }
         });
     });
+
+    if ( self.opt.debug )
+        util.log('End listener added');
     self.conn.addListener("end", function() {
         if ( self.opt.debug )
             util.log('Connection got "end" event');
     });
+
+    if ( self.opt.debug )
+        util.log('Close listener added');
     self.conn.addListener("close", function() {
         if ( self.opt.debug )
             util.log('Connection got "close" event');
@@ -700,6 +735,8 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
             self.connect( retryCount + 1 );
         }, self.opt.retryDelay );
     });
+    if ( self.opt.debug )
+        util.log('Error listener added');
     self.conn.addListener("error", function(exception) {
         self.emit("netError", exception);
     });


### PR DESCRIPTION
RE: SASL over SSL failing, https://github.com/martynsmith/node-irc/issues/250. It should allow SASL to work over SSL or non-SSL connections, by firing an event after a connection happens (SSL or not), that does the same negotiation either way. This also adds a ton of debug logging that is useful for getting SASL working.
