### PR TITLE
Ignoring rpl_luserunknown.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -185,6 +185,7 @@ function Client(server, nick, opt) {
             case "rpl_localusers":
             case "rpl_globalusers":
             case "rpl_statsconn":
+            case "rpl_luserunknown":
                 // Random welcome crap, ignoring
                 break;
             case "err_nicknameinuse":


### PR DESCRIPTION
This is only used when the client has registered with the server, or on LUSERS command. No client I know really does anything but ignore it.