### PR TITLE
update README regarding npm and the 0.3.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # irc
 > Modern IRC client library for Node
 
-__Attention:__ node-irc is currently being rewritten. If you're looking for the last released version, please checkout the [0.3.x branch](https://github.com/martynsmith/node-irc/tree/0.3.x).
+__Attention:__ node-irc is currently being rewritten. If you're looking for the last released version (e.g. using **npm**), please checkout the [0.3.x branch](https://github.com/martynsmith/node-irc/tree/0.3.x)
 
 node-irc is a modern IRC client library for Node, exposing a simple interface to deal with IRC connections.
 


### PR DESCRIPTION
In the issue #254, an user is asking why the main README is showing an use case of the master branch while npm installs the 0.3.x branch. I added a small clarification on the master README explaining the situation.