### PR TITLE
Add travis with lint and tests

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "validateIndentation": 4
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
   "validateIndentation": 4,
   "requireMultipleVarDecl": null,
-  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties"
+  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+  "safeContextKeyword": "self"
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,4 @@
 {
-  "validateIndentation": 4
+  "validateIndentation": 4,
+  "requireMultipleVarDecl": null
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,5 @@
 {
   "validateIndentation": 4,
-  "requireMultipleVarDecl": null
+  "requireMultipleVarDecl": null,
+  "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.8"
+script:
+  - "npm run-script lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
+before_install:
+  - npm install -g npm
 script:
   - "npm run-script lint"
+  - "npm test"

--- a/example/bot.js
+++ b/example/bot.js
@@ -18,12 +18,12 @@ bot.addListener('message#blah', function (from, message) {
 bot.addListener('message', function (from, to, message) {
     console.log('%s => %s: %s', from, to, message);
 
-    if ( to.match(/^[#&]/) ) {
+    if (to.match(/^[#&]/)) {
         // channel message
-        if ( message.match(/hello/i) ) {
+        if (message.match(/hello/i)) {
             bot.say(to, 'Hello there ' + from);
         }
-        if ( message.match(/dance/) ) {
+        if (message.match(/dance/)) {
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);

--- a/example/bot.js
+++ b/example/bot.js
@@ -24,10 +24,10 @@ bot.addListener('message', function(from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if (message.match(/dance/)) {
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D\\-<\u0001'); }, 1000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D|-<\u0001');  }, 2000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D/-<\u0001');  }, 3000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D|-<\u0001');  }, 4000);
         }
     }
     else {

--- a/example/bot.js
+++ b/example/bot.js
@@ -32,6 +32,7 @@ bot.addListener('message', function(from, to, message) {
     }
     else {
         // private message
+        console.log('private message');
     }
 });
 bot.addListener('pm', function(nick, message) {

--- a/example/bot.js
+++ b/example/bot.js
@@ -24,10 +24,10 @@ bot.addListener('message', function (from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if ( message.match(/dance/) ) {
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001") }, 1000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001")  }, 2000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001")  }, 3000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001")  }, 4000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
         }
     }
     else {

--- a/example/bot.js
+++ b/example/bot.js
@@ -11,11 +11,11 @@ bot.addListener('error', function(message) {
     console.error('ERROR: %s: %s', message.command, message.args.join(' '));
 });
 
-bot.addListener('message#blah', function (from, message) {
+bot.addListener('message#blah', function(from, message) {
     console.log('<%s> %s', from, message);
 });
 
-bot.addListener('message', function (from, to, message) {
+bot.addListener('message', function(from, to, message) {
     console.log('%s => %s: %s', from, to, message);
 
     if (to.match(/^[#&]/)) {
@@ -24,10 +24,10 @@ bot.addListener('message', function (from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if (message.match(/dance/)) {
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
         }
     }
     else {

--- a/example/bot.js
+++ b/example/bot.js
@@ -4,7 +4,7 @@ var irc = require('../');
 
 var bot = new irc.Client('irc.dollyfish.net.nz', 'nodebot', {
     debug: true,
-    channels: ['#blah', '#test'],
+    channels: ['#blah', '#test']
 });
 
 bot.addListener('error', function(message) {

--- a/example/secure.js
+++ b/example/secure.js
@@ -46,6 +46,7 @@ bot.addListener('message', function(from, to, message) {
     }
     else {
         // private message
+        console.log('private message');
     }
 });
 bot.addListener('pm', function(nick, message) {

--- a/example/secure.js
+++ b/example/secure.js
@@ -32,12 +32,12 @@ bot.addListener('message#blah', function (from, message) {
 bot.addListener('message', function (from, to, message) {
     console.log('%s => %s: %s', from, to, message);
 
-    if ( to.match(/^[#&]/) ) {
+    if (to.match(/^[#&]/)) {
         // channel message
-        if ( message.match(/hello/i) ) {
+        if (message.match(/hello/i)) {
             bot.say(to, 'Hello there ' + from);
         }
-        if ( message.match(/dance/) ) {
+        if (message.match(/dance/)) {
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
             setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);

--- a/example/secure.js
+++ b/example/secure.js
@@ -38,10 +38,10 @@ bot.addListener('message', function (from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if ( message.match(/dance/) ) {
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001") }, 1000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001")  }, 2000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001")  }, 3000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001")  }, 4000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
+            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
         }
     }
     else {

--- a/example/secure.js
+++ b/example/secure.js
@@ -25,11 +25,11 @@ bot.addListener('error', function(message) {
     console.error('ERROR: %s: %s', message.command, message.args.join(' '));
 });
 
-bot.addListener('message#blah', function (from, message) {
+bot.addListener('message#blah', function(from, message) {
     console.log('<%s> %s', from, message);
 });
 
-bot.addListener('message', function (from, to, message) {
+bot.addListener('message', function(from, to, message) {
     console.log('%s => %s: %s', from, to, message);
 
     if (to.match(/^[#&]/)) {
@@ -38,10 +38,10 @@ bot.addListener('message', function (from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if (message.match(/dance/)) {
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
-            setTimeout(function () { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
+            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
         }
     }
     else {

--- a/example/secure.js
+++ b/example/secure.js
@@ -38,10 +38,10 @@ bot.addListener('message', function(from, to, message) {
             bot.say(to, 'Hello there ' + from);
         }
         if (message.match(/dance/)) {
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D\\-<\u0001"); }, 1000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 2000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D/-<\u0001");  }, 3000);
-            setTimeout(function() { bot.say(to, "\u0001ACTION dances: :D|-<\u0001");  }, 4000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D\\-<\u0001'); }, 1000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D|-<\u0001');  }, 2000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D/-<\u0001');  }, 3000);
+            setTimeout(function() { bot.say(to, '\u0001ACTION dances: :D|-<\u0001');  }, 4000);
         }
     }
     else {

--- a/example/secure.js
+++ b/example/secure.js
@@ -18,7 +18,7 @@ var bot = new irc.Client('chat.us.freenode.net', 'nodebot', {
 	port: 6697,
     debug: true,
 	secure: options,
-    channels: ['#botwar'],
+    channels: ['#botwar']
 });
 
 bot.addListener('error', function(message) {

--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,21 +1,21 @@
 module.exports = { // {{{
-   001: {
+   '001': {
       name: 'rpl_welcome',
       type: 'reply'
    },
-   002: {
+   '002': {
       name: 'rpl_yourhost',
       type: 'reply'
    },
-   003: {
+   '003': {
       name: 'rpl_created',
       type: 'reply'
    },
-   004: {
+   '004': {
       name: 'rpl_myinfo',
       type: 'reply'
    },
-   005: {
+   '005': {
       name: 'rpl_isupport',
       type: 'reply'
    },

--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,514 +1,514 @@
 module.exports = { // {{{
-   "001" : {
-      "name" : "rpl_welcome",
-      "type" : "reply"
-   },
-   "002" : {
-      "name" : "rpl_yourhost",
-      "type" : "reply"
-   },
-   "003" : {
-      "name" : "rpl_created",
-      "type" : "reply"
-   },
-   "004" : {
-      "name" : "rpl_myinfo",
-      "type" : "reply"
-   },
-   "005" : {
-      "name" : "rpl_isupport",
-      "type" : "reply"
-   },
-   "200" : {
-      "name" : "rpl_tracelink",
-      "type" : "reply"
-   },
-   "201" : {
-      "name" : "rpl_traceconnecting",
-      "type" : "reply"
-   },
-   "202" : {
-      "name" : "rpl_tracehandshake",
-      "type" : "reply"
-   },
-   "203" : {
-      "name" : "rpl_traceunknown",
-      "type" : "reply"
-   },
-   "204" : {
-      "name" : "rpl_traceoperator",
-      "type" : "reply"
-   },
-   "205" : {
-      "name" : "rpl_traceuser",
-      "type" : "reply"
-   },
-   "206" : {
-      "name" : "rpl_traceserver",
-      "type" : "reply"
-   },
-   "208" : {
-      "name" : "rpl_tracenewtype",
-      "type" : "reply"
-   },
-   "211" : {
-      "name" : "rpl_statslinkinfo",
-      "type" : "reply"
-   },
-   "212" : {
-      "name" : "rpl_statscommands",
-      "type" : "reply"
-   },
-   "213" : {
-      "name" : "rpl_statscline",
-      "type" : "reply"
-   },
-   "214" : {
-      "name" : "rpl_statsnline",
-      "type" : "reply"
-   },
-   "215" : {
-      "name" : "rpl_statsiline",
-      "type" : "reply"
-   },
-   "216" : {
-      "name" : "rpl_statskline",
-      "type" : "reply"
-   },
-   "218" : {
-      "name" : "rpl_statsyline",
-      "type" : "reply"
-   },
-   "219" : {
-      "name" : "rpl_endofstats",
-      "type" : "reply"
-   },
-   "221" : {
-      "name" : "rpl_umodeis",
-      "type" : "reply"
-   },
-   "241" : {
-      "name" : "rpl_statslline",
-      "type" : "reply"
-   },
-   "242" : {
-      "name" : "rpl_statsuptime",
-      "type" : "reply"
-   },
-   "243" : {
-      "name" : "rpl_statsoline",
-      "type" : "reply"
-   },
-   "244" : {
-      "name" : "rpl_statshline",
-      "type" : "reply"
-   },
-   "250" : {
-      "name" : "rpl_statsconn",
-      "type" : "reply"
-   },
-   "251" : {
-      "name" : "rpl_luserclient",
-      "type" : "reply"
-   },
-   "252" : {
-      "name" : "rpl_luserop",
-      "type" : "reply"
-   },
-   "253" : {
-      "name" : "rpl_luserunknown",
-      "type" : "reply"
-   },
-   "254" : {
-      "name" : "rpl_luserchannels",
-      "type" : "reply"
-   },
-   "255" : {
-      "name" : "rpl_luserme",
-      "type" : "reply"
-   },
-   "256" : {
-      "name" : "rpl_adminme",
-      "type" : "reply"
-   },
-   "257" : {
-      "name" : "rpl_adminloc1",
-      "type" : "reply"
-   },
-   "258" : {
-      "name" : "rpl_adminloc2",
-      "type" : "reply"
-   },
-   "259" : {
-      "name" : "rpl_adminemail",
-      "type" : "reply"
-   },
-   "261" : {
-      "name" : "rpl_tracelog",
-      "type" : "reply"
-   },
-   "265" : {
-      "name" : "rpl_localusers",
-      "type" : "reply"
-   },
-   "266" : {
-      "name" : "rpl_globalusers",
-      "type" : "reply"
-   },
-   "300" : {
-      "name" : "rpl_none",
-      "type" : "reply"
-   },
-   "301" : {
-      "name" : "rpl_away",
-      "type" : "reply"
-   },
-   "302" : {
-      "name" : "rpl_userhost",
-      "type" : "reply"
-   },
-   "303" : {
-      "name" : "rpl_ison",
-      "type" : "reply"
-   },
-   "305" : {
-      "name" : "rpl_unaway",
-      "type" : "reply"
-   },
-   "306" : {
-      "name" : "rpl_nowaway",
-      "type" : "reply"
-   },
-   "311" : {
-      "name" : "rpl_whoisuser",
-      "type" : "reply"
-   },
-   "312" : {
-      "name" : "rpl_whoisserver",
-      "type" : "reply"
-   },
-   "313" : {
-      "name" : "rpl_whoisoperator",
-      "type" : "reply"
-   },
-   "314" : {
-      "name" : "rpl_whowasuser",
-      "type" : "reply"
-   },
-   "315" : {
-      "name" : "rpl_endofwho",
-      "type" : "reply"
-   },
-   "317" : {
-      "name" : "rpl_whoisidle",
-      "type" : "reply"
-   },
-   "318" : {
-      "name" : "rpl_endofwhois",
-      "type" : "reply"
-   },
-   "319" : {
-      "name" : "rpl_whoischannels",
-      "type" : "reply"
-   },
-   "321" : {
-      "name" : "rpl_liststart",
-      "type" : "reply"
-   },
-   "322" : {
-      "name" : "rpl_list",
-      "type" : "reply"
-   },
-   "323" : {
-      "name" : "rpl_listend",
-      "type" : "reply"
-   },
-   "324" : {
-      "name" : "rpl_channelmodeis",
-      "type" : "reply"
-   },
-   "329" : {
-      "name" : "rpl_creationtime",
-      "type" : "reply"
-   },
-   "331" : {
-      "name" : "rpl_notopic",
-      "type" : "reply"
-   },
-   "332" : {
-      "name" : "rpl_topic",
-      "type" : "reply"
-   },
-   "333" : {
-      "name" : "rpl_topicwhotime",
-      "type" : "reply"
-   },
-   "341" : {
-      "name" : "rpl_inviting",
-      "type" : "reply"
-   },
-   "342" : {
-      "name" : "rpl_summoning",
-      "type" : "reply"
-   },
-   "351" : {
-      "name" : "rpl_version",
-      "type" : "reply"
-   },
-   "352" : {
-      "name" : "rpl_whoreply",
-      "type" : "reply"
-   },
-   "353" : {
-      "name" : "rpl_namreply",
-      "type" : "reply"
-   },
-   "364" : {
-      "name" : "rpl_links",
-      "type" : "reply"
-   },
-   "365" : {
-      "name" : "rpl_endoflinks",
-      "type" : "reply"
-   },
-   "366" : {
-      "name" : "rpl_endofnames",
-      "type" : "reply"
-   },
-   "367" : {
-      "name" : "rpl_banlist",
-      "type" : "reply"
-   },
-   "368" : {
-      "name" : "rpl_endofbanlist",
-      "type" : "reply"
-   },
-   "369" : {
-      "name" : "rpl_endofwhowas",
-      "type" : "reply"
-   },
-   "371" : {
-      "name" : "rpl_info",
-      "type" : "reply"
-   },
-   "372" : {
-      "name" : "rpl_motd",
-      "type" : "reply"
-   },
-   "374" : {
-      "name" : "rpl_endofinfo",
-      "type" : "reply"
-   },
-   "375" : {
-      "name" : "rpl_motdstart",
-      "type" : "reply"
-   },
-   "376" : {
-      "name" : "rpl_endofmotd",
-      "type" : "reply"
-   },
-   "381" : {
-      "name" : "rpl_youreoper",
-      "type" : "reply"
-   },
-   "382" : {
-      "name" : "rpl_rehashing",
-      "type" : "reply"
-   },
-   "391" : {
-      "name" : "rpl_time",
-      "type" : "reply"
-   },
-   "392" : {
-      "name" : "rpl_usersstart",
-      "type" : "reply"
-   },
-   "393" : {
-      "name" : "rpl_users",
-      "type" : "reply"
-   },
-   "394" : {
-      "name" : "rpl_endofusers",
-      "type" : "reply"
-   },
-   "395" : {
-      "name" : "rpl_nousers",
-      "type" : "reply"
-   },
-   "401" : {
-      "name" : "err_nosuchnick",
-      "type" : "error"
-   },
-   "402" : {
-      "name" : "err_nosuchserver",
-      "type" : "error"
-   },
-   "403" : {
-      "name" : "err_nosuchchannel",
-      "type" : "error"
-   },
-   "404" : {
-      "name" : "err_cannotsendtochan",
-      "type" : "error"
-   },
-   "405" : {
-      "name" : "err_toomanychannels",
-      "type" : "error"
-   },
-   "406" : {
-      "name" : "err_wasnosuchnick",
-      "type" : "error"
-   },
-   "407" : {
-      "name" : "err_toomanytargets",
-      "type" : "error"
-   },
-   "409" : {
-      "name" : "err_noorigin",
-      "type" : "error"
-   },
-   "411" : {
-      "name" : "err_norecipient",
-      "type" : "error"
-   },
-   "412" : {
-      "name" : "err_notexttosend",
-      "type" : "error"
-   },
-   "413" : {
-      "name" : "err_notoplevel",
-      "type" : "error"
-   },
-   "414" : {
-      "name" : "err_wildtoplevel",
-      "type" : "error"
-   },
-   "421" : {
-      "name" : "err_unknowncommand",
-      "type" : "error"
-   },
-   "422" : {
-      "name" : "err_nomotd",
-      "type" : "error"
-   },
-   "423" : {
-      "name" : "err_noadmininfo",
-      "type" : "error"
-   },
-   "424" : {
-      "name" : "err_fileerror",
-      "type" : "error"
-   },
-   "431" : {
-      "name" : "err_nonicknamegiven",
-      "type" : "error"
-   },
-   "432" : {
-      "name" : "err_erroneusnickname",
-      "type" : "error"
-   },
-   "433" : {
-      "name" : "err_nicknameinuse",
-      "type" : "error"
-   },
-   "436" : {
-      "name" : "err_nickcollision",
-      "type" : "error"
-   },
-   "441" : {
-      "name" : "err_usernotinchannel",
-      "type" : "error"
-   },
-   "442" : {
-      "name" : "err_notonchannel",
-      "type" : "error"
-   },
-   "443" : {
-      "name" : "err_useronchannel",
-      "type" : "error"
-   },
-   "444" : {
-      "name" : "err_nologin",
-      "type" : "error"
-   },
-   "445" : {
-      "name" : "err_summondisabled",
-      "type" : "error"
-   },
-   "446" : {
-      "name" : "err_usersdisabled",
-      "type" : "error"
-   },
-   "451" : {
-      "name" : "err_notregistered",
-      "type" : "error"
-   },
-   "461" : {
-      "name" : "err_needmoreparams",
-      "type" : "error"
-   },
-   "462" : {
-      "name" : "err_alreadyregistred",
-      "type" : "error"
-   },
-   "463" : {
-      "name" : "err_nopermforhost",
-      "type" : "error"
-   },
-   "464" : {
-      "name" : "err_passwdmismatch",
-      "type" : "error"
-   },
-   "465" : {
-      "name" : "err_yourebannedcreep",
-      "type" : "error"
-   },
-   "467" : {
-      "name" : "err_keyset",
-      "type" : "error"
-   },
-   "471" : {
-      "name" : "err_channelisfull",
-      "type" : "error"
-   },
-   "472" : {
-      "name" : "err_unknownmode",
-      "type" : "error"
-   },
-   "473" : {
-      "name" : "err_inviteonlychan",
-      "type" : "error"
-   },
-   "474" : {
-      "name" : "err_bannedfromchan",
-      "type" : "error"
-   },
-   "475" : {
-      "name" : "err_badchannelkey",
-      "type" : "error"
-   },
-   "481" : {
-      "name" : "err_noprivileges",
-      "type" : "error"
-   },
-   "482" : {
-      "name" : "err_chanoprivsneeded",
-      "type" : "error"
-   },
-   "483" : {
-      "name" : "err_cantkillserver",
-      "type" : "error"
-   },
-   "491" : {
-      "name" : "err_nooperhost",
-      "type" : "error"
-   },
-   "501" : {
-      "name" : "err_umodeunknownflag",
-      "type" : "error"
-   },
-   "502" : {
-      "name" : "err_usersdontmatch",
-      "type" : "error"
+   '001' : {
+      'name' : 'rpl_welcome',
+      'type' : 'reply'
+   },
+   '002' : {
+      'name' : 'rpl_yourhost',
+      'type' : 'reply'
+   },
+   '003' : {
+      'name' : 'rpl_created',
+      'type' : 'reply'
+   },
+   '004' : {
+      'name' : 'rpl_myinfo',
+      'type' : 'reply'
+   },
+   '005' : {
+      'name' : 'rpl_isupport',
+      'type' : 'reply'
+   },
+   '200' : {
+      'name' : 'rpl_tracelink',
+      'type' : 'reply'
+   },
+   '201' : {
+      'name' : 'rpl_traceconnecting',
+      'type' : 'reply'
+   },
+   '202' : {
+      'name' : 'rpl_tracehandshake',
+      'type' : 'reply'
+   },
+   '203' : {
+      'name' : 'rpl_traceunknown',
+      'type' : 'reply'
+   },
+   '204' : {
+      'name' : 'rpl_traceoperator',
+      'type' : 'reply'
+   },
+   '205' : {
+      'name' : 'rpl_traceuser',
+      'type' : 'reply'
+   },
+   '206' : {
+      'name' : 'rpl_traceserver',
+      'type' : 'reply'
+   },
+   '208' : {
+      'name' : 'rpl_tracenewtype',
+      'type' : 'reply'
+   },
+   '211' : {
+      'name' : 'rpl_statslinkinfo',
+      'type' : 'reply'
+   },
+   '212' : {
+      'name' : 'rpl_statscommands',
+      'type' : 'reply'
+   },
+   '213' : {
+      'name' : 'rpl_statscline',
+      'type' : 'reply'
+   },
+   '214' : {
+      'name' : 'rpl_statsnline',
+      'type' : 'reply'
+   },
+   '215' : {
+      'name' : 'rpl_statsiline',
+      'type' : 'reply'
+   },
+   '216' : {
+      'name' : 'rpl_statskline',
+      'type' : 'reply'
+   },
+   '218' : {
+      'name' : 'rpl_statsyline',
+      'type' : 'reply'
+   },
+   '219' : {
+      'name' : 'rpl_endofstats',
+      'type' : 'reply'
+   },
+   '221' : {
+      'name' : 'rpl_umodeis',
+      'type' : 'reply'
+   },
+   '241' : {
+      'name' : 'rpl_statslline',
+      'type' : 'reply'
+   },
+   '242' : {
+      'name' : 'rpl_statsuptime',
+      'type' : 'reply'
+   },
+   '243' : {
+      'name' : 'rpl_statsoline',
+      'type' : 'reply'
+   },
+   '244' : {
+      'name' : 'rpl_statshline',
+      'type' : 'reply'
+   },
+   '250' : {
+      'name' : 'rpl_statsconn',
+      'type' : 'reply'
+   },
+   '251' : {
+      'name' : 'rpl_luserclient',
+      'type' : 'reply'
+   },
+   '252' : {
+      'name' : 'rpl_luserop',
+      'type' : 'reply'
+   },
+   '253' : {
+      'name' : 'rpl_luserunknown',
+      'type' : 'reply'
+   },
+   '254' : {
+      'name' : 'rpl_luserchannels',
+      'type' : 'reply'
+   },
+   '255' : {
+      'name' : 'rpl_luserme',
+      'type' : 'reply'
+   },
+   '256' : {
+      'name' : 'rpl_adminme',
+      'type' : 'reply'
+   },
+   '257' : {
+      'name' : 'rpl_adminloc1',
+      'type' : 'reply'
+   },
+   '258' : {
+      'name' : 'rpl_adminloc2',
+      'type' : 'reply'
+   },
+   '259' : {
+      'name' : 'rpl_adminemail',
+      'type' : 'reply'
+   },
+   '261' : {
+      'name' : 'rpl_tracelog',
+      'type' : 'reply'
+   },
+   '265' : {
+      'name' : 'rpl_localusers',
+      'type' : 'reply'
+   },
+   '266' : {
+      'name' : 'rpl_globalusers',
+      'type' : 'reply'
+   },
+   '300' : {
+      'name' : 'rpl_none',
+      'type' : 'reply'
+   },
+   '301' : {
+      'name' : 'rpl_away',
+      'type' : 'reply'
+   },
+   '302' : {
+      'name' : 'rpl_userhost',
+      'type' : 'reply'
+   },
+   '303' : {
+      'name' : 'rpl_ison',
+      'type' : 'reply'
+   },
+   '305' : {
+      'name' : 'rpl_unaway',
+      'type' : 'reply'
+   },
+   '306' : {
+      'name' : 'rpl_nowaway',
+      'type' : 'reply'
+   },
+   '311' : {
+      'name' : 'rpl_whoisuser',
+      'type' : 'reply'
+   },
+   '312' : {
+      'name' : 'rpl_whoisserver',
+      'type' : 'reply'
+   },
+   '313' : {
+      'name' : 'rpl_whoisoperator',
+      'type' : 'reply'
+   },
+   '314' : {
+      'name' : 'rpl_whowasuser',
+      'type' : 'reply'
+   },
+   '315' : {
+      'name' : 'rpl_endofwho',
+      'type' : 'reply'
+   },
+   '317' : {
+      'name' : 'rpl_whoisidle',
+      'type' : 'reply'
+   },
+   '318' : {
+      'name' : 'rpl_endofwhois',
+      'type' : 'reply'
+   },
+   '319' : {
+      'name' : 'rpl_whoischannels',
+      'type' : 'reply'
+   },
+   '321' : {
+      'name' : 'rpl_liststart',
+      'type' : 'reply'
+   },
+   '322' : {
+      'name' : 'rpl_list',
+      'type' : 'reply'
+   },
+   '323' : {
+      'name' : 'rpl_listend',
+      'type' : 'reply'
+   },
+   '324' : {
+      'name' : 'rpl_channelmodeis',
+      'type' : 'reply'
+   },
+   '329' : {
+      'name' : 'rpl_creationtime',
+      'type' : 'reply'
+   },
+   '331' : {
+      'name' : 'rpl_notopic',
+      'type' : 'reply'
+   },
+   '332' : {
+      'name' : 'rpl_topic',
+      'type' : 'reply'
+   },
+   '333' : {
+      'name' : 'rpl_topicwhotime',
+      'type' : 'reply'
+   },
+   '341' : {
+      'name' : 'rpl_inviting',
+      'type' : 'reply'
+   },
+   '342' : {
+      'name' : 'rpl_summoning',
+      'type' : 'reply'
+   },
+   '351' : {
+      'name' : 'rpl_version',
+      'type' : 'reply'
+   },
+   '352' : {
+      'name' : 'rpl_whoreply',
+      'type' : 'reply'
+   },
+   '353' : {
+      'name' : 'rpl_namreply',
+      'type' : 'reply'
+   },
+   '364' : {
+      'name' : 'rpl_links',
+      'type' : 'reply'
+   },
+   '365' : {
+      'name' : 'rpl_endoflinks',
+      'type' : 'reply'
+   },
+   '366' : {
+      'name' : 'rpl_endofnames',
+      'type' : 'reply'
+   },
+   '367' : {
+      'name' : 'rpl_banlist',
+      'type' : 'reply'
+   },
+   '368' : {
+      'name' : 'rpl_endofbanlist',
+      'type' : 'reply'
+   },
+   '369' : {
+      'name' : 'rpl_endofwhowas',
+      'type' : 'reply'
+   },
+   '371' : {
+      'name' : 'rpl_info',
+      'type' : 'reply'
+   },
+   '372' : {
+      'name' : 'rpl_motd',
+      'type' : 'reply'
+   },
+   '374' : {
+      'name' : 'rpl_endofinfo',
+      'type' : 'reply'
+   },
+   '375' : {
+      'name' : 'rpl_motdstart',
+      'type' : 'reply'
+   },
+   '376' : {
+      'name' : 'rpl_endofmotd',
+      'type' : 'reply'
+   },
+   '381' : {
+      'name' : 'rpl_youreoper',
+      'type' : 'reply'
+   },
+   '382' : {
+      'name' : 'rpl_rehashing',
+      'type' : 'reply'
+   },
+   '391' : {
+      'name' : 'rpl_time',
+      'type' : 'reply'
+   },
+   '392' : {
+      'name' : 'rpl_usersstart',
+      'type' : 'reply'
+   },
+   '393' : {
+      'name' : 'rpl_users',
+      'type' : 'reply'
+   },
+   '394' : {
+      'name' : 'rpl_endofusers',
+      'type' : 'reply'
+   },
+   '395' : {
+      'name' : 'rpl_nousers',
+      'type' : 'reply'
+   },
+   '401' : {
+      'name' : 'err_nosuchnick',
+      'type' : 'error'
+   },
+   '402' : {
+      'name' : 'err_nosuchserver',
+      'type' : 'error'
+   },
+   '403' : {
+      'name' : 'err_nosuchchannel',
+      'type' : 'error'
+   },
+   '404' : {
+      'name' : 'err_cannotsendtochan',
+      'type' : 'error'
+   },
+   '405' : {
+      'name' : 'err_toomanychannels',
+      'type' : 'error'
+   },
+   '406' : {
+      'name' : 'err_wasnosuchnick',
+      'type' : 'error'
+   },
+   '407' : {
+      'name' : 'err_toomanytargets',
+      'type' : 'error'
+   },
+   '409' : {
+      'name' : 'err_noorigin',
+      'type' : 'error'
+   },
+   '411' : {
+      'name' : 'err_norecipient',
+      'type' : 'error'
+   },
+   '412' : {
+      'name' : 'err_notexttosend',
+      'type' : 'error'
+   },
+   '413' : {
+      'name' : 'err_notoplevel',
+      'type' : 'error'
+   },
+   '414' : {
+      'name' : 'err_wildtoplevel',
+      'type' : 'error'
+   },
+   '421' : {
+      'name' : 'err_unknowncommand',
+      'type' : 'error'
+   },
+   '422' : {
+      'name' : 'err_nomotd',
+      'type' : 'error'
+   },
+   '423' : {
+      'name' : 'err_noadmininfo',
+      'type' : 'error'
+   },
+   '424' : {
+      'name' : 'err_fileerror',
+      'type' : 'error'
+   },
+   '431' : {
+      'name' : 'err_nonicknamegiven',
+      'type' : 'error'
+   },
+   '432' : {
+      'name' : 'err_erroneusnickname',
+      'type' : 'error'
+   },
+   '433' : {
+      'name' : 'err_nicknameinuse',
+      'type' : 'error'
+   },
+   '436' : {
+      'name' : 'err_nickcollision',
+      'type' : 'error'
+   },
+   '441' : {
+      'name' : 'err_usernotinchannel',
+      'type' : 'error'
+   },
+   '442' : {
+      'name' : 'err_notonchannel',
+      'type' : 'error'
+   },
+   '443' : {
+      'name' : 'err_useronchannel',
+      'type' : 'error'
+   },
+   '444' : {
+      'name' : 'err_nologin',
+      'type' : 'error'
+   },
+   '445' : {
+      'name' : 'err_summondisabled',
+      'type' : 'error'
+   },
+   '446' : {
+      'name' : 'err_usersdisabled',
+      'type' : 'error'
+   },
+   '451' : {
+      'name' : 'err_notregistered',
+      'type' : 'error'
+   },
+   '461' : {
+      'name' : 'err_needmoreparams',
+      'type' : 'error'
+   },
+   '462' : {
+      'name' : 'err_alreadyregistred',
+      'type' : 'error'
+   },
+   '463' : {
+      'name' : 'err_nopermforhost',
+      'type' : 'error'
+   },
+   '464' : {
+      'name' : 'err_passwdmismatch',
+      'type' : 'error'
+   },
+   '465' : {
+      'name' : 'err_yourebannedcreep',
+      'type' : 'error'
+   },
+   '467' : {
+      'name' : 'err_keyset',
+      'type' : 'error'
+   },
+   '471' : {
+      'name' : 'err_channelisfull',
+      'type' : 'error'
+   },
+   '472' : {
+      'name' : 'err_unknownmode',
+      'type' : 'error'
+   },
+   '473' : {
+      'name' : 'err_inviteonlychan',
+      'type' : 'error'
+   },
+   '474' : {
+      'name' : 'err_bannedfromchan',
+      'type' : 'error'
+   },
+   '475' : {
+      'name' : 'err_badchannelkey',
+      'type' : 'error'
+   },
+   '481' : {
+      'name' : 'err_noprivileges',
+      'type' : 'error'
+   },
+   '482' : {
+      'name' : 'err_chanoprivsneeded',
+      'type' : 'error'
+   },
+   '483' : {
+      'name' : 'err_cantkillserver',
+      'type' : 'error'
+   },
+   '491' : {
+      'name' : 'err_nooperhost',
+      'type' : 'error'
+   },
+   '501' : {
+      'name' : 'err_umodeunknownflag',
+      'type' : 'error'
+   },
+   '502' : {
+      'name' : 'err_usersdontmatch',
+      'type' : 'error'
    }
 }; // }}}

--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,514 +1,514 @@
 module.exports = { // {{{
-   '001': {
-      'name': 'rpl_welcome',
-      'type': 'reply'
-   },
-   '002': {
-      'name': 'rpl_yourhost',
-      'type': 'reply'
-   },
-   '003': {
-      'name': 'rpl_created',
-      'type': 'reply'
-   },
-   '004': {
-      'name': 'rpl_myinfo',
-      'type': 'reply'
-   },
-   '005': {
-      'name': 'rpl_isupport',
-      'type': 'reply'
-   },
-   '200': {
-      'name': 'rpl_tracelink',
-      'type': 'reply'
-   },
-   '201': {
-      'name': 'rpl_traceconnecting',
-      'type': 'reply'
-   },
-   '202': {
-      'name': 'rpl_tracehandshake',
-      'type': 'reply'
-   },
-   '203': {
-      'name': 'rpl_traceunknown',
-      'type': 'reply'
-   },
-   '204': {
-      'name': 'rpl_traceoperator',
-      'type': 'reply'
-   },
-   '205': {
-      'name': 'rpl_traceuser',
-      'type': 'reply'
-   },
-   '206': {
-      'name': 'rpl_traceserver',
-      'type': 'reply'
-   },
-   '208': {
-      'name': 'rpl_tracenewtype',
-      'type': 'reply'
-   },
-   '211': {
-      'name': 'rpl_statslinkinfo',
-      'type': 'reply'
-   },
-   '212': {
-      'name': 'rpl_statscommands',
-      'type': 'reply'
-   },
-   '213': {
-      'name': 'rpl_statscline',
-      'type': 'reply'
-   },
-   '214': {
-      'name': 'rpl_statsnline',
-      'type': 'reply'
-   },
-   '215': {
-      'name': 'rpl_statsiline',
-      'type': 'reply'
-   },
-   '216': {
-      'name': 'rpl_statskline',
-      'type': 'reply'
-   },
-   '218': {
-      'name': 'rpl_statsyline',
-      'type': 'reply'
-   },
-   '219': {
-      'name': 'rpl_endofstats',
-      'type': 'reply'
-   },
-   '221': {
-      'name': 'rpl_umodeis',
-      'type': 'reply'
-   },
-   '241': {
-      'name': 'rpl_statslline',
-      'type': 'reply'
-   },
-   '242': {
-      'name': 'rpl_statsuptime',
-      'type': 'reply'
-   },
-   '243': {
-      'name': 'rpl_statsoline',
-      'type': 'reply'
-   },
-   '244': {
-      'name': 'rpl_statshline',
-      'type': 'reply'
-   },
-   '250': {
-      'name': 'rpl_statsconn',
-      'type': 'reply'
-   },
-   '251': {
-      'name': 'rpl_luserclient',
-      'type': 'reply'
-   },
-   '252': {
-      'name': 'rpl_luserop',
-      'type': 'reply'
-   },
-   '253': {
-      'name': 'rpl_luserunknown',
-      'type': 'reply'
-   },
-   '254': {
-      'name': 'rpl_luserchannels',
-      'type': 'reply'
-   },
-   '255': {
-      'name': 'rpl_luserme',
-      'type': 'reply'
-   },
-   '256': {
-      'name': 'rpl_adminme',
-      'type': 'reply'
-   },
-   '257': {
-      'name': 'rpl_adminloc1',
-      'type': 'reply'
-   },
-   '258': {
-      'name': 'rpl_adminloc2',
-      'type': 'reply'
-   },
-   '259': {
-      'name': 'rpl_adminemail',
-      'type': 'reply'
-   },
-   '261': {
-      'name': 'rpl_tracelog',
-      'type': 'reply'
-   },
-   '265': {
-      'name': 'rpl_localusers',
-      'type': 'reply'
-   },
-   '266': {
-      'name': 'rpl_globalusers',
-      'type': 'reply'
-   },
-   '300': {
-      'name': 'rpl_none',
-      'type': 'reply'
-   },
-   '301': {
-      'name': 'rpl_away',
-      'type': 'reply'
-   },
-   '302': {
-      'name': 'rpl_userhost',
-      'type': 'reply'
-   },
-   '303': {
-      'name': 'rpl_ison',
-      'type': 'reply'
-   },
-   '305': {
-      'name': 'rpl_unaway',
-      'type': 'reply'
-   },
-   '306': {
-      'name': 'rpl_nowaway',
-      'type': 'reply'
-   },
-   '311': {
-      'name': 'rpl_whoisuser',
-      'type': 'reply'
-   },
-   '312': {
-      'name': 'rpl_whoisserver',
-      'type': 'reply'
-   },
-   '313': {
-      'name': 'rpl_whoisoperator',
-      'type': 'reply'
-   },
-   '314': {
-      'name': 'rpl_whowasuser',
-      'type': 'reply'
-   },
-   '315': {
-      'name': 'rpl_endofwho',
-      'type': 'reply'
-   },
-   '317': {
-      'name': 'rpl_whoisidle',
-      'type': 'reply'
-   },
-   '318': {
-      'name': 'rpl_endofwhois',
-      'type': 'reply'
-   },
-   '319': {
-      'name': 'rpl_whoischannels',
-      'type': 'reply'
-   },
-   '321': {
-      'name': 'rpl_liststart',
-      'type': 'reply'
-   },
-   '322': {
-      'name': 'rpl_list',
-      'type': 'reply'
-   },
-   '323': {
-      'name': 'rpl_listend',
-      'type': 'reply'
-   },
-   '324': {
-      'name': 'rpl_channelmodeis',
-      'type': 'reply'
-   },
-   '329': {
-      'name': 'rpl_creationtime',
-      'type': 'reply'
-   },
-   '331': {
-      'name': 'rpl_notopic',
-      'type': 'reply'
-   },
-   '332': {
-      'name': 'rpl_topic',
-      'type': 'reply'
-   },
-   '333': {
-      'name': 'rpl_topicwhotime',
-      'type': 'reply'
-   },
-   '341': {
-      'name': 'rpl_inviting',
-      'type': 'reply'
-   },
-   '342': {
-      'name': 'rpl_summoning',
-      'type': 'reply'
-   },
-   '351': {
-      'name': 'rpl_version',
-      'type': 'reply'
-   },
-   '352': {
-      'name': 'rpl_whoreply',
-      'type': 'reply'
-   },
-   '353': {
-      'name': 'rpl_namreply',
-      'type': 'reply'
-   },
-   '364': {
-      'name': 'rpl_links',
-      'type': 'reply'
-   },
-   '365': {
-      'name': 'rpl_endoflinks',
-      'type': 'reply'
-   },
-   '366': {
-      'name': 'rpl_endofnames',
-      'type': 'reply'
-   },
-   '367': {
-      'name': 'rpl_banlist',
-      'type': 'reply'
-   },
-   '368': {
-      'name': 'rpl_endofbanlist',
-      'type': 'reply'
-   },
-   '369': {
-      'name': 'rpl_endofwhowas',
-      'type': 'reply'
-   },
-   '371': {
-      'name': 'rpl_info',
-      'type': 'reply'
-   },
-   '372': {
-      'name': 'rpl_motd',
-      'type': 'reply'
-   },
-   '374': {
-      'name': 'rpl_endofinfo',
-      'type': 'reply'
-   },
-   '375': {
-      'name': 'rpl_motdstart',
-      'type': 'reply'
-   },
-   '376': {
-      'name': 'rpl_endofmotd',
-      'type': 'reply'
-   },
-   '381': {
-      'name': 'rpl_youreoper',
-      'type': 'reply'
-   },
-   '382': {
-      'name': 'rpl_rehashing',
-      'type': 'reply'
-   },
-   '391': {
-      'name': 'rpl_time',
-      'type': 'reply'
-   },
-   '392': {
-      'name': 'rpl_usersstart',
-      'type': 'reply'
-   },
-   '393': {
-      'name': 'rpl_users',
-      'type': 'reply'
-   },
-   '394': {
-      'name': 'rpl_endofusers',
-      'type': 'reply'
-   },
-   '395': {
-      'name': 'rpl_nousers',
-      'type': 'reply'
-   },
-   '401': {
-      'name': 'err_nosuchnick',
-      'type': 'error'
-   },
-   '402': {
-      'name': 'err_nosuchserver',
-      'type': 'error'
-   },
-   '403': {
-      'name': 'err_nosuchchannel',
-      'type': 'error'
-   },
-   '404': {
-      'name': 'err_cannotsendtochan',
-      'type': 'error'
-   },
-   '405': {
-      'name': 'err_toomanychannels',
-      'type': 'error'
-   },
-   '406': {
-      'name': 'err_wasnosuchnick',
-      'type': 'error'
-   },
-   '407': {
-      'name': 'err_toomanytargets',
-      'type': 'error'
-   },
-   '409': {
-      'name': 'err_noorigin',
-      'type': 'error'
-   },
-   '411': {
-      'name': 'err_norecipient',
-      'type': 'error'
-   },
-   '412': {
-      'name': 'err_notexttosend',
-      'type': 'error'
-   },
-   '413': {
-      'name': 'err_notoplevel',
-      'type': 'error'
-   },
-   '414': {
-      'name': 'err_wildtoplevel',
-      'type': 'error'
-   },
-   '421': {
-      'name': 'err_unknowncommand',
-      'type': 'error'
-   },
-   '422': {
-      'name': 'err_nomotd',
-      'type': 'error'
-   },
-   '423': {
-      'name': 'err_noadmininfo',
-      'type': 'error'
-   },
-   '424': {
-      'name': 'err_fileerror',
-      'type': 'error'
-   },
-   '431': {
-      'name': 'err_nonicknamegiven',
-      'type': 'error'
-   },
-   '432': {
-      'name': 'err_erroneusnickname',
-      'type': 'error'
-   },
-   '433': {
-      'name': 'err_nicknameinuse',
-      'type': 'error'
-   },
-   '436': {
-      'name': 'err_nickcollision',
-      'type': 'error'
-   },
-   '441': {
-      'name': 'err_usernotinchannel',
-      'type': 'error'
-   },
-   '442': {
-      'name': 'err_notonchannel',
-      'type': 'error'
-   },
-   '443': {
-      'name': 'err_useronchannel',
-      'type': 'error'
-   },
-   '444': {
-      'name': 'err_nologin',
-      'type': 'error'
-   },
-   '445': {
-      'name': 'err_summondisabled',
-      'type': 'error'
-   },
-   '446': {
-      'name': 'err_usersdisabled',
-      'type': 'error'
-   },
-   '451': {
-      'name': 'err_notregistered',
-      'type': 'error'
-   },
-   '461': {
-      'name': 'err_needmoreparams',
-      'type': 'error'
-   },
-   '462': {
-      'name': 'err_alreadyregistred',
-      'type': 'error'
-   },
-   '463': {
-      'name': 'err_nopermforhost',
-      'type': 'error'
-   },
-   '464': {
-      'name': 'err_passwdmismatch',
-      'type': 'error'
-   },
-   '465': {
-      'name': 'err_yourebannedcreep',
-      'type': 'error'
-   },
-   '467': {
-      'name': 'err_keyset',
-      'type': 'error'
-   },
-   '471': {
-      'name': 'err_channelisfull',
-      'type': 'error'
-   },
-   '472': {
-      'name': 'err_unknownmode',
-      'type': 'error'
-   },
-   '473': {
-      'name': 'err_inviteonlychan',
-      'type': 'error'
-   },
-   '474': {
-      'name': 'err_bannedfromchan',
-      'type': 'error'
-   },
-   '475': {
-      'name': 'err_badchannelkey',
-      'type': 'error'
-   },
-   '481': {
-      'name': 'err_noprivileges',
-      'type': 'error'
-   },
-   '482': {
-      'name': 'err_chanoprivsneeded',
-      'type': 'error'
-   },
-   '483': {
-      'name': 'err_cantkillserver',
-      'type': 'error'
-   },
-   '491': {
-      'name': 'err_nooperhost',
-      'type': 'error'
-   },
-   '501': {
-      'name': 'err_umodeunknownflag',
-      'type': 'error'
-   },
-   '502': {
-      'name': 'err_usersdontmatch',
-      'type': 'error'
+   001: {
+      name: 'rpl_welcome',
+      type: 'reply'
+   },
+   002: {
+      name: 'rpl_yourhost',
+      type: 'reply'
+   },
+   003: {
+      name: 'rpl_created',
+      type: 'reply'
+   },
+   004: {
+      name: 'rpl_myinfo',
+      type: 'reply'
+   },
+   005: {
+      name: 'rpl_isupport',
+      type: 'reply'
+   },
+   200: {
+      name: 'rpl_tracelink',
+      type: 'reply'
+   },
+   201: {
+      name: 'rpl_traceconnecting',
+      type: 'reply'
+   },
+   202: {
+      name: 'rpl_tracehandshake',
+      type: 'reply'
+   },
+   203: {
+      name: 'rpl_traceunknown',
+      type: 'reply'
+   },
+   204: {
+      name: 'rpl_traceoperator',
+      type: 'reply'
+   },
+   205: {
+      name: 'rpl_traceuser',
+      type: 'reply'
+   },
+   206: {
+      name: 'rpl_traceserver',
+      type: 'reply'
+   },
+   208: {
+      name: 'rpl_tracenewtype',
+      type: 'reply'
+   },
+   211: {
+      name: 'rpl_statslinkinfo',
+      type: 'reply'
+   },
+   212: {
+      name: 'rpl_statscommands',
+      type: 'reply'
+   },
+   213: {
+      name: 'rpl_statscline',
+      type: 'reply'
+   },
+   214: {
+      name: 'rpl_statsnline',
+      type: 'reply'
+   },
+   215: {
+      name: 'rpl_statsiline',
+      type: 'reply'
+   },
+   216: {
+      name: 'rpl_statskline',
+      type: 'reply'
+   },
+   218: {
+      name: 'rpl_statsyline',
+      type: 'reply'
+   },
+   219: {
+      name: 'rpl_endofstats',
+      type: 'reply'
+   },
+   221: {
+      name: 'rpl_umodeis',
+      type: 'reply'
+   },
+   241: {
+      name: 'rpl_statslline',
+      type: 'reply'
+   },
+   242: {
+      name: 'rpl_statsuptime',
+      type: 'reply'
+   },
+   243: {
+      name: 'rpl_statsoline',
+      type: 'reply'
+   },
+   244: {
+      name: 'rpl_statshline',
+      type: 'reply'
+   },
+   250: {
+      name: 'rpl_statsconn',
+      type: 'reply'
+   },
+   251: {
+      name: 'rpl_luserclient',
+      type: 'reply'
+   },
+   252: {
+      name: 'rpl_luserop',
+      type: 'reply'
+   },
+   253: {
+      name: 'rpl_luserunknown',
+      type: 'reply'
+   },
+   254: {
+      name: 'rpl_luserchannels',
+      type: 'reply'
+   },
+   255: {
+      name: 'rpl_luserme',
+      type: 'reply'
+   },
+   256: {
+      name: 'rpl_adminme',
+      type: 'reply'
+   },
+   257: {
+      name: 'rpl_adminloc1',
+      type: 'reply'
+   },
+   258: {
+      name: 'rpl_adminloc2',
+      type: 'reply'
+   },
+   259: {
+      name: 'rpl_adminemail',
+      type: 'reply'
+   },
+   261: {
+      name: 'rpl_tracelog',
+      type: 'reply'
+   },
+   265: {
+      name: 'rpl_localusers',
+      type: 'reply'
+   },
+   266: {
+      name: 'rpl_globalusers',
+      type: 'reply'
+   },
+   300: {
+      name: 'rpl_none',
+      type: 'reply'
+   },
+   301: {
+      name: 'rpl_away',
+      type: 'reply'
+   },
+   302: {
+      name: 'rpl_userhost',
+      type: 'reply'
+   },
+   303: {
+      name: 'rpl_ison',
+      type: 'reply'
+   },
+   305: {
+      name: 'rpl_unaway',
+      type: 'reply'
+   },
+   306: {
+      name: 'rpl_nowaway',
+      type: 'reply'
+   },
+   311: {
+      name: 'rpl_whoisuser',
+      type: 'reply'
+   },
+   312: {
+      name: 'rpl_whoisserver',
+      type: 'reply'
+   },
+   313: {
+      name: 'rpl_whoisoperator',
+      type: 'reply'
+   },
+   314: {
+      name: 'rpl_whowasuser',
+      type: 'reply'
+   },
+   315: {
+      name: 'rpl_endofwho',
+      type: 'reply'
+   },
+   317: {
+      name: 'rpl_whoisidle',
+      type: 'reply'
+   },
+   318: {
+      name: 'rpl_endofwhois',
+      type: 'reply'
+   },
+   319: {
+      name: 'rpl_whoischannels',
+      type: 'reply'
+   },
+   321: {
+      name: 'rpl_liststart',
+      type: 'reply'
+   },
+   322: {
+      name: 'rpl_list',
+      type: 'reply'
+   },
+   323: {
+      name: 'rpl_listend',
+      type: 'reply'
+   },
+   324: {
+      name: 'rpl_channelmodeis',
+      type: 'reply'
+   },
+   329: {
+      name: 'rpl_creationtime',
+      type: 'reply'
+   },
+   331: {
+      name: 'rpl_notopic',
+      type: 'reply'
+   },
+   332: {
+      name: 'rpl_topic',
+      type: 'reply'
+   },
+   333: {
+      name: 'rpl_topicwhotime',
+      type: 'reply'
+   },
+   341: {
+      name: 'rpl_inviting',
+      type: 'reply'
+   },
+   342: {
+      name: 'rpl_summoning',
+      type: 'reply'
+   },
+   351: {
+      name: 'rpl_version',
+      type: 'reply'
+   },
+   352: {
+      name: 'rpl_whoreply',
+      type: 'reply'
+   },
+   353: {
+      name: 'rpl_namreply',
+      type: 'reply'
+   },
+   364: {
+      name: 'rpl_links',
+      type: 'reply'
+   },
+   365: {
+      name: 'rpl_endoflinks',
+      type: 'reply'
+   },
+   366: {
+      name: 'rpl_endofnames',
+      type: 'reply'
+   },
+   367: {
+      name: 'rpl_banlist',
+      type: 'reply'
+   },
+   368: {
+      name: 'rpl_endofbanlist',
+      type: 'reply'
+   },
+   369: {
+      name: 'rpl_endofwhowas',
+      type: 'reply'
+   },
+   371: {
+      name: 'rpl_info',
+      type: 'reply'
+   },
+   372: {
+      name: 'rpl_motd',
+      type: 'reply'
+   },
+   374: {
+      name: 'rpl_endofinfo',
+      type: 'reply'
+   },
+   375: {
+      name: 'rpl_motdstart',
+      type: 'reply'
+   },
+   376: {
+      name: 'rpl_endofmotd',
+      type: 'reply'
+   },
+   381: {
+      name: 'rpl_youreoper',
+      type: 'reply'
+   },
+   382: {
+      name: 'rpl_rehashing',
+      type: 'reply'
+   },
+   391: {
+      name: 'rpl_time',
+      type: 'reply'
+   },
+   392: {
+      name: 'rpl_usersstart',
+      type: 'reply'
+   },
+   393: {
+      name: 'rpl_users',
+      type: 'reply'
+   },
+   394: {
+      name: 'rpl_endofusers',
+      type: 'reply'
+   },
+   395: {
+      name: 'rpl_nousers',
+      type: 'reply'
+   },
+   401: {
+      name: 'err_nosuchnick',
+      type: 'error'
+   },
+   402: {
+      name: 'err_nosuchserver',
+      type: 'error'
+   },
+   403: {
+      name: 'err_nosuchchannel',
+      type: 'error'
+   },
+   404: {
+      name: 'err_cannotsendtochan',
+      type: 'error'
+   },
+   405: {
+      name: 'err_toomanychannels',
+      type: 'error'
+   },
+   406: {
+      name: 'err_wasnosuchnick',
+      type: 'error'
+   },
+   407: {
+      name: 'err_toomanytargets',
+      type: 'error'
+   },
+   409: {
+      name: 'err_noorigin',
+      type: 'error'
+   },
+   411: {
+      name: 'err_norecipient',
+      type: 'error'
+   },
+   412: {
+      name: 'err_notexttosend',
+      type: 'error'
+   },
+   413: {
+      name: 'err_notoplevel',
+      type: 'error'
+   },
+   414: {
+      name: 'err_wildtoplevel',
+      type: 'error'
+   },
+   421: {
+      name: 'err_unknowncommand',
+      type: 'error'
+   },
+   422: {
+      name: 'err_nomotd',
+      type: 'error'
+   },
+   423: {
+      name: 'err_noadmininfo',
+      type: 'error'
+   },
+   424: {
+      name: 'err_fileerror',
+      type: 'error'
+   },
+   431: {
+      name: 'err_nonicknamegiven',
+      type: 'error'
+   },
+   432: {
+      name: 'err_erroneusnickname',
+      type: 'error'
+   },
+   433: {
+      name: 'err_nicknameinuse',
+      type: 'error'
+   },
+   436: {
+      name: 'err_nickcollision',
+      type: 'error'
+   },
+   441: {
+      name: 'err_usernotinchannel',
+      type: 'error'
+   },
+   442: {
+      name: 'err_notonchannel',
+      type: 'error'
+   },
+   443: {
+      name: 'err_useronchannel',
+      type: 'error'
+   },
+   444: {
+      name: 'err_nologin',
+      type: 'error'
+   },
+   445: {
+      name: 'err_summondisabled',
+      type: 'error'
+   },
+   446: {
+      name: 'err_usersdisabled',
+      type: 'error'
+   },
+   451: {
+      name: 'err_notregistered',
+      type: 'error'
+   },
+   461: {
+      name: 'err_needmoreparams',
+      type: 'error'
+   },
+   462: {
+      name: 'err_alreadyregistred',
+      type: 'error'
+   },
+   463: {
+      name: 'err_nopermforhost',
+      type: 'error'
+   },
+   464: {
+      name: 'err_passwdmismatch',
+      type: 'error'
+   },
+   465: {
+      name: 'err_yourebannedcreep',
+      type: 'error'
+   },
+   467: {
+      name: 'err_keyset',
+      type: 'error'
+   },
+   471: {
+      name: 'err_channelisfull',
+      type: 'error'
+   },
+   472: {
+      name: 'err_unknownmode',
+      type: 'error'
+   },
+   473: {
+      name: 'err_inviteonlychan',
+      type: 'error'
+   },
+   474: {
+      name: 'err_bannedfromchan',
+      type: 'error'
+   },
+   475: {
+      name: 'err_badchannelkey',
+      type: 'error'
+   },
+   481: {
+      name: 'err_noprivileges',
+      type: 'error'
+   },
+   482: {
+      name: 'err_chanoprivsneeded',
+      type: 'error'
+   },
+   483: {
+      name: 'err_cantkillserver',
+      type: 'error'
+   },
+   491: {
+      name: 'err_nooperhost',
+      type: 'error'
+   },
+   501: {
+      name: 'err_umodeunknownflag',
+      type: 'error'
+   },
+   502: {
+      name: 'err_usersdontmatch',
+      type: 'error'
    }
 }; // }}}

--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,514 +1,514 @@
 module.exports = { // {{{
-   '001' : {
-      'name' : 'rpl_welcome',
-      'type' : 'reply'
-   },
-   '002' : {
-      'name' : 'rpl_yourhost',
-      'type' : 'reply'
-   },
-   '003' : {
-      'name' : 'rpl_created',
-      'type' : 'reply'
-   },
-   '004' : {
-      'name' : 'rpl_myinfo',
-      'type' : 'reply'
-   },
-   '005' : {
-      'name' : 'rpl_isupport',
-      'type' : 'reply'
-   },
-   '200' : {
-      'name' : 'rpl_tracelink',
-      'type' : 'reply'
-   },
-   '201' : {
-      'name' : 'rpl_traceconnecting',
-      'type' : 'reply'
-   },
-   '202' : {
-      'name' : 'rpl_tracehandshake',
-      'type' : 'reply'
-   },
-   '203' : {
-      'name' : 'rpl_traceunknown',
-      'type' : 'reply'
-   },
-   '204' : {
-      'name' : 'rpl_traceoperator',
-      'type' : 'reply'
-   },
-   '205' : {
-      'name' : 'rpl_traceuser',
-      'type' : 'reply'
-   },
-   '206' : {
-      'name' : 'rpl_traceserver',
-      'type' : 'reply'
-   },
-   '208' : {
-      'name' : 'rpl_tracenewtype',
-      'type' : 'reply'
-   },
-   '211' : {
-      'name' : 'rpl_statslinkinfo',
-      'type' : 'reply'
-   },
-   '212' : {
-      'name' : 'rpl_statscommands',
-      'type' : 'reply'
-   },
-   '213' : {
-      'name' : 'rpl_statscline',
-      'type' : 'reply'
-   },
-   '214' : {
-      'name' : 'rpl_statsnline',
-      'type' : 'reply'
-   },
-   '215' : {
-      'name' : 'rpl_statsiline',
-      'type' : 'reply'
-   },
-   '216' : {
-      'name' : 'rpl_statskline',
-      'type' : 'reply'
-   },
-   '218' : {
-      'name' : 'rpl_statsyline',
-      'type' : 'reply'
-   },
-   '219' : {
-      'name' : 'rpl_endofstats',
-      'type' : 'reply'
-   },
-   '221' : {
-      'name' : 'rpl_umodeis',
-      'type' : 'reply'
-   },
-   '241' : {
-      'name' : 'rpl_statslline',
-      'type' : 'reply'
-   },
-   '242' : {
-      'name' : 'rpl_statsuptime',
-      'type' : 'reply'
-   },
-   '243' : {
-      'name' : 'rpl_statsoline',
-      'type' : 'reply'
-   },
-   '244' : {
-      'name' : 'rpl_statshline',
-      'type' : 'reply'
-   },
-   '250' : {
-      'name' : 'rpl_statsconn',
-      'type' : 'reply'
-   },
-   '251' : {
-      'name' : 'rpl_luserclient',
-      'type' : 'reply'
-   },
-   '252' : {
-      'name' : 'rpl_luserop',
-      'type' : 'reply'
-   },
-   '253' : {
-      'name' : 'rpl_luserunknown',
-      'type' : 'reply'
-   },
-   '254' : {
-      'name' : 'rpl_luserchannels',
-      'type' : 'reply'
-   },
-   '255' : {
-      'name' : 'rpl_luserme',
-      'type' : 'reply'
-   },
-   '256' : {
-      'name' : 'rpl_adminme',
-      'type' : 'reply'
-   },
-   '257' : {
-      'name' : 'rpl_adminloc1',
-      'type' : 'reply'
-   },
-   '258' : {
-      'name' : 'rpl_adminloc2',
-      'type' : 'reply'
-   },
-   '259' : {
-      'name' : 'rpl_adminemail',
-      'type' : 'reply'
-   },
-   '261' : {
-      'name' : 'rpl_tracelog',
-      'type' : 'reply'
-   },
-   '265' : {
-      'name' : 'rpl_localusers',
-      'type' : 'reply'
-   },
-   '266' : {
-      'name' : 'rpl_globalusers',
-      'type' : 'reply'
-   },
-   '300' : {
-      'name' : 'rpl_none',
-      'type' : 'reply'
-   },
-   '301' : {
-      'name' : 'rpl_away',
-      'type' : 'reply'
-   },
-   '302' : {
-      'name' : 'rpl_userhost',
-      'type' : 'reply'
-   },
-   '303' : {
-      'name' : 'rpl_ison',
-      'type' : 'reply'
-   },
-   '305' : {
-      'name' : 'rpl_unaway',
-      'type' : 'reply'
-   },
-   '306' : {
-      'name' : 'rpl_nowaway',
-      'type' : 'reply'
-   },
-   '311' : {
-      'name' : 'rpl_whoisuser',
-      'type' : 'reply'
-   },
-   '312' : {
-      'name' : 'rpl_whoisserver',
-      'type' : 'reply'
-   },
-   '313' : {
-      'name' : 'rpl_whoisoperator',
-      'type' : 'reply'
-   },
-   '314' : {
-      'name' : 'rpl_whowasuser',
-      'type' : 'reply'
-   },
-   '315' : {
-      'name' : 'rpl_endofwho',
-      'type' : 'reply'
-   },
-   '317' : {
-      'name' : 'rpl_whoisidle',
-      'type' : 'reply'
-   },
-   '318' : {
-      'name' : 'rpl_endofwhois',
-      'type' : 'reply'
-   },
-   '319' : {
-      'name' : 'rpl_whoischannels',
-      'type' : 'reply'
-   },
-   '321' : {
-      'name' : 'rpl_liststart',
-      'type' : 'reply'
-   },
-   '322' : {
-      'name' : 'rpl_list',
-      'type' : 'reply'
-   },
-   '323' : {
-      'name' : 'rpl_listend',
-      'type' : 'reply'
-   },
-   '324' : {
-      'name' : 'rpl_channelmodeis',
-      'type' : 'reply'
-   },
-   '329' : {
-      'name' : 'rpl_creationtime',
-      'type' : 'reply'
-   },
-   '331' : {
-      'name' : 'rpl_notopic',
-      'type' : 'reply'
-   },
-   '332' : {
-      'name' : 'rpl_topic',
-      'type' : 'reply'
-   },
-   '333' : {
-      'name' : 'rpl_topicwhotime',
-      'type' : 'reply'
-   },
-   '341' : {
-      'name' : 'rpl_inviting',
-      'type' : 'reply'
-   },
-   '342' : {
-      'name' : 'rpl_summoning',
-      'type' : 'reply'
-   },
-   '351' : {
-      'name' : 'rpl_version',
-      'type' : 'reply'
-   },
-   '352' : {
-      'name' : 'rpl_whoreply',
-      'type' : 'reply'
-   },
-   '353' : {
-      'name' : 'rpl_namreply',
-      'type' : 'reply'
-   },
-   '364' : {
-      'name' : 'rpl_links',
-      'type' : 'reply'
-   },
-   '365' : {
-      'name' : 'rpl_endoflinks',
-      'type' : 'reply'
-   },
-   '366' : {
-      'name' : 'rpl_endofnames',
-      'type' : 'reply'
-   },
-   '367' : {
-      'name' : 'rpl_banlist',
-      'type' : 'reply'
-   },
-   '368' : {
-      'name' : 'rpl_endofbanlist',
-      'type' : 'reply'
-   },
-   '369' : {
-      'name' : 'rpl_endofwhowas',
-      'type' : 'reply'
-   },
-   '371' : {
-      'name' : 'rpl_info',
-      'type' : 'reply'
-   },
-   '372' : {
-      'name' : 'rpl_motd',
-      'type' : 'reply'
-   },
-   '374' : {
-      'name' : 'rpl_endofinfo',
-      'type' : 'reply'
-   },
-   '375' : {
-      'name' : 'rpl_motdstart',
-      'type' : 'reply'
-   },
-   '376' : {
-      'name' : 'rpl_endofmotd',
-      'type' : 'reply'
-   },
-   '381' : {
-      'name' : 'rpl_youreoper',
-      'type' : 'reply'
-   },
-   '382' : {
-      'name' : 'rpl_rehashing',
-      'type' : 'reply'
-   },
-   '391' : {
-      'name' : 'rpl_time',
-      'type' : 'reply'
-   },
-   '392' : {
-      'name' : 'rpl_usersstart',
-      'type' : 'reply'
-   },
-   '393' : {
-      'name' : 'rpl_users',
-      'type' : 'reply'
-   },
-   '394' : {
-      'name' : 'rpl_endofusers',
-      'type' : 'reply'
-   },
-   '395' : {
-      'name' : 'rpl_nousers',
-      'type' : 'reply'
-   },
-   '401' : {
-      'name' : 'err_nosuchnick',
-      'type' : 'error'
-   },
-   '402' : {
-      'name' : 'err_nosuchserver',
-      'type' : 'error'
-   },
-   '403' : {
-      'name' : 'err_nosuchchannel',
-      'type' : 'error'
-   },
-   '404' : {
-      'name' : 'err_cannotsendtochan',
-      'type' : 'error'
-   },
-   '405' : {
-      'name' : 'err_toomanychannels',
-      'type' : 'error'
-   },
-   '406' : {
-      'name' : 'err_wasnosuchnick',
-      'type' : 'error'
-   },
-   '407' : {
-      'name' : 'err_toomanytargets',
-      'type' : 'error'
-   },
-   '409' : {
-      'name' : 'err_noorigin',
-      'type' : 'error'
-   },
-   '411' : {
-      'name' : 'err_norecipient',
-      'type' : 'error'
-   },
-   '412' : {
-      'name' : 'err_notexttosend',
-      'type' : 'error'
-   },
-   '413' : {
-      'name' : 'err_notoplevel',
-      'type' : 'error'
-   },
-   '414' : {
-      'name' : 'err_wildtoplevel',
-      'type' : 'error'
-   },
-   '421' : {
-      'name' : 'err_unknowncommand',
-      'type' : 'error'
-   },
-   '422' : {
-      'name' : 'err_nomotd',
-      'type' : 'error'
-   },
-   '423' : {
-      'name' : 'err_noadmininfo',
-      'type' : 'error'
-   },
-   '424' : {
-      'name' : 'err_fileerror',
-      'type' : 'error'
-   },
-   '431' : {
-      'name' : 'err_nonicknamegiven',
-      'type' : 'error'
-   },
-   '432' : {
-      'name' : 'err_erroneusnickname',
-      'type' : 'error'
-   },
-   '433' : {
-      'name' : 'err_nicknameinuse',
-      'type' : 'error'
-   },
-   '436' : {
-      'name' : 'err_nickcollision',
-      'type' : 'error'
-   },
-   '441' : {
-      'name' : 'err_usernotinchannel',
-      'type' : 'error'
-   },
-   '442' : {
-      'name' : 'err_notonchannel',
-      'type' : 'error'
-   },
-   '443' : {
-      'name' : 'err_useronchannel',
-      'type' : 'error'
-   },
-   '444' : {
-      'name' : 'err_nologin',
-      'type' : 'error'
-   },
-   '445' : {
-      'name' : 'err_summondisabled',
-      'type' : 'error'
-   },
-   '446' : {
-      'name' : 'err_usersdisabled',
-      'type' : 'error'
-   },
-   '451' : {
-      'name' : 'err_notregistered',
-      'type' : 'error'
-   },
-   '461' : {
-      'name' : 'err_needmoreparams',
-      'type' : 'error'
-   },
-   '462' : {
-      'name' : 'err_alreadyregistred',
-      'type' : 'error'
-   },
-   '463' : {
-      'name' : 'err_nopermforhost',
-      'type' : 'error'
-   },
-   '464' : {
-      'name' : 'err_passwdmismatch',
-      'type' : 'error'
-   },
-   '465' : {
-      'name' : 'err_yourebannedcreep',
-      'type' : 'error'
-   },
-   '467' : {
-      'name' : 'err_keyset',
-      'type' : 'error'
-   },
-   '471' : {
-      'name' : 'err_channelisfull',
-      'type' : 'error'
-   },
-   '472' : {
-      'name' : 'err_unknownmode',
-      'type' : 'error'
-   },
-   '473' : {
-      'name' : 'err_inviteonlychan',
-      'type' : 'error'
-   },
-   '474' : {
-      'name' : 'err_bannedfromchan',
-      'type' : 'error'
-   },
-   '475' : {
-      'name' : 'err_badchannelkey',
-      'type' : 'error'
-   },
-   '481' : {
-      'name' : 'err_noprivileges',
-      'type' : 'error'
-   },
-   '482' : {
-      'name' : 'err_chanoprivsneeded',
-      'type' : 'error'
-   },
-   '483' : {
-      'name' : 'err_cantkillserver',
-      'type' : 'error'
-   },
-   '491' : {
-      'name' : 'err_nooperhost',
-      'type' : 'error'
-   },
-   '501' : {
-      'name' : 'err_umodeunknownflag',
-      'type' : 'error'
-   },
-   '502' : {
-      'name' : 'err_usersdontmatch',
-      'type' : 'error'
+   '001': {
+      'name': 'rpl_welcome',
+      'type': 'reply'
+   },
+   '002': {
+      'name': 'rpl_yourhost',
+      'type': 'reply'
+   },
+   '003': {
+      'name': 'rpl_created',
+      'type': 'reply'
+   },
+   '004': {
+      'name': 'rpl_myinfo',
+      'type': 'reply'
+   },
+   '005': {
+      'name': 'rpl_isupport',
+      'type': 'reply'
+   },
+   '200': {
+      'name': 'rpl_tracelink',
+      'type': 'reply'
+   },
+   '201': {
+      'name': 'rpl_traceconnecting',
+      'type': 'reply'
+   },
+   '202': {
+      'name': 'rpl_tracehandshake',
+      'type': 'reply'
+   },
+   '203': {
+      'name': 'rpl_traceunknown',
+      'type': 'reply'
+   },
+   '204': {
+      'name': 'rpl_traceoperator',
+      'type': 'reply'
+   },
+   '205': {
+      'name': 'rpl_traceuser',
+      'type': 'reply'
+   },
+   '206': {
+      'name': 'rpl_traceserver',
+      'type': 'reply'
+   },
+   '208': {
+      'name': 'rpl_tracenewtype',
+      'type': 'reply'
+   },
+   '211': {
+      'name': 'rpl_statslinkinfo',
+      'type': 'reply'
+   },
+   '212': {
+      'name': 'rpl_statscommands',
+      'type': 'reply'
+   },
+   '213': {
+      'name': 'rpl_statscline',
+      'type': 'reply'
+   },
+   '214': {
+      'name': 'rpl_statsnline',
+      'type': 'reply'
+   },
+   '215': {
+      'name': 'rpl_statsiline',
+      'type': 'reply'
+   },
+   '216': {
+      'name': 'rpl_statskline',
+      'type': 'reply'
+   },
+   '218': {
+      'name': 'rpl_statsyline',
+      'type': 'reply'
+   },
+   '219': {
+      'name': 'rpl_endofstats',
+      'type': 'reply'
+   },
+   '221': {
+      'name': 'rpl_umodeis',
+      'type': 'reply'
+   },
+   '241': {
+      'name': 'rpl_statslline',
+      'type': 'reply'
+   },
+   '242': {
+      'name': 'rpl_statsuptime',
+      'type': 'reply'
+   },
+   '243': {
+      'name': 'rpl_statsoline',
+      'type': 'reply'
+   },
+   '244': {
+      'name': 'rpl_statshline',
+      'type': 'reply'
+   },
+   '250': {
+      'name': 'rpl_statsconn',
+      'type': 'reply'
+   },
+   '251': {
+      'name': 'rpl_luserclient',
+      'type': 'reply'
+   },
+   '252': {
+      'name': 'rpl_luserop',
+      'type': 'reply'
+   },
+   '253': {
+      'name': 'rpl_luserunknown',
+      'type': 'reply'
+   },
+   '254': {
+      'name': 'rpl_luserchannels',
+      'type': 'reply'
+   },
+   '255': {
+      'name': 'rpl_luserme',
+      'type': 'reply'
+   },
+   '256': {
+      'name': 'rpl_adminme',
+      'type': 'reply'
+   },
+   '257': {
+      'name': 'rpl_adminloc1',
+      'type': 'reply'
+   },
+   '258': {
+      'name': 'rpl_adminloc2',
+      'type': 'reply'
+   },
+   '259': {
+      'name': 'rpl_adminemail',
+      'type': 'reply'
+   },
+   '261': {
+      'name': 'rpl_tracelog',
+      'type': 'reply'
+   },
+   '265': {
+      'name': 'rpl_localusers',
+      'type': 'reply'
+   },
+   '266': {
+      'name': 'rpl_globalusers',
+      'type': 'reply'
+   },
+   '300': {
+      'name': 'rpl_none',
+      'type': 'reply'
+   },
+   '301': {
+      'name': 'rpl_away',
+      'type': 'reply'
+   },
+   '302': {
+      'name': 'rpl_userhost',
+      'type': 'reply'
+   },
+   '303': {
+      'name': 'rpl_ison',
+      'type': 'reply'
+   },
+   '305': {
+      'name': 'rpl_unaway',
+      'type': 'reply'
+   },
+   '306': {
+      'name': 'rpl_nowaway',
+      'type': 'reply'
+   },
+   '311': {
+      'name': 'rpl_whoisuser',
+      'type': 'reply'
+   },
+   '312': {
+      'name': 'rpl_whoisserver',
+      'type': 'reply'
+   },
+   '313': {
+      'name': 'rpl_whoisoperator',
+      'type': 'reply'
+   },
+   '314': {
+      'name': 'rpl_whowasuser',
+      'type': 'reply'
+   },
+   '315': {
+      'name': 'rpl_endofwho',
+      'type': 'reply'
+   },
+   '317': {
+      'name': 'rpl_whoisidle',
+      'type': 'reply'
+   },
+   '318': {
+      'name': 'rpl_endofwhois',
+      'type': 'reply'
+   },
+   '319': {
+      'name': 'rpl_whoischannels',
+      'type': 'reply'
+   },
+   '321': {
+      'name': 'rpl_liststart',
+      'type': 'reply'
+   },
+   '322': {
+      'name': 'rpl_list',
+      'type': 'reply'
+   },
+   '323': {
+      'name': 'rpl_listend',
+      'type': 'reply'
+   },
+   '324': {
+      'name': 'rpl_channelmodeis',
+      'type': 'reply'
+   },
+   '329': {
+      'name': 'rpl_creationtime',
+      'type': 'reply'
+   },
+   '331': {
+      'name': 'rpl_notopic',
+      'type': 'reply'
+   },
+   '332': {
+      'name': 'rpl_topic',
+      'type': 'reply'
+   },
+   '333': {
+      'name': 'rpl_topicwhotime',
+      'type': 'reply'
+   },
+   '341': {
+      'name': 'rpl_inviting',
+      'type': 'reply'
+   },
+   '342': {
+      'name': 'rpl_summoning',
+      'type': 'reply'
+   },
+   '351': {
+      'name': 'rpl_version',
+      'type': 'reply'
+   },
+   '352': {
+      'name': 'rpl_whoreply',
+      'type': 'reply'
+   },
+   '353': {
+      'name': 'rpl_namreply',
+      'type': 'reply'
+   },
+   '364': {
+      'name': 'rpl_links',
+      'type': 'reply'
+   },
+   '365': {
+      'name': 'rpl_endoflinks',
+      'type': 'reply'
+   },
+   '366': {
+      'name': 'rpl_endofnames',
+      'type': 'reply'
+   },
+   '367': {
+      'name': 'rpl_banlist',
+      'type': 'reply'
+   },
+   '368': {
+      'name': 'rpl_endofbanlist',
+      'type': 'reply'
+   },
+   '369': {
+      'name': 'rpl_endofwhowas',
+      'type': 'reply'
+   },
+   '371': {
+      'name': 'rpl_info',
+      'type': 'reply'
+   },
+   '372': {
+      'name': 'rpl_motd',
+      'type': 'reply'
+   },
+   '374': {
+      'name': 'rpl_endofinfo',
+      'type': 'reply'
+   },
+   '375': {
+      'name': 'rpl_motdstart',
+      'type': 'reply'
+   },
+   '376': {
+      'name': 'rpl_endofmotd',
+      'type': 'reply'
+   },
+   '381': {
+      'name': 'rpl_youreoper',
+      'type': 'reply'
+   },
+   '382': {
+      'name': 'rpl_rehashing',
+      'type': 'reply'
+   },
+   '391': {
+      'name': 'rpl_time',
+      'type': 'reply'
+   },
+   '392': {
+      'name': 'rpl_usersstart',
+      'type': 'reply'
+   },
+   '393': {
+      'name': 'rpl_users',
+      'type': 'reply'
+   },
+   '394': {
+      'name': 'rpl_endofusers',
+      'type': 'reply'
+   },
+   '395': {
+      'name': 'rpl_nousers',
+      'type': 'reply'
+   },
+   '401': {
+      'name': 'err_nosuchnick',
+      'type': 'error'
+   },
+   '402': {
+      'name': 'err_nosuchserver',
+      'type': 'error'
+   },
+   '403': {
+      'name': 'err_nosuchchannel',
+      'type': 'error'
+   },
+   '404': {
+      'name': 'err_cannotsendtochan',
+      'type': 'error'
+   },
+   '405': {
+      'name': 'err_toomanychannels',
+      'type': 'error'
+   },
+   '406': {
+      'name': 'err_wasnosuchnick',
+      'type': 'error'
+   },
+   '407': {
+      'name': 'err_toomanytargets',
+      'type': 'error'
+   },
+   '409': {
+      'name': 'err_noorigin',
+      'type': 'error'
+   },
+   '411': {
+      'name': 'err_norecipient',
+      'type': 'error'
+   },
+   '412': {
+      'name': 'err_notexttosend',
+      'type': 'error'
+   },
+   '413': {
+      'name': 'err_notoplevel',
+      'type': 'error'
+   },
+   '414': {
+      'name': 'err_wildtoplevel',
+      'type': 'error'
+   },
+   '421': {
+      'name': 'err_unknowncommand',
+      'type': 'error'
+   },
+   '422': {
+      'name': 'err_nomotd',
+      'type': 'error'
+   },
+   '423': {
+      'name': 'err_noadmininfo',
+      'type': 'error'
+   },
+   '424': {
+      'name': 'err_fileerror',
+      'type': 'error'
+   },
+   '431': {
+      'name': 'err_nonicknamegiven',
+      'type': 'error'
+   },
+   '432': {
+      'name': 'err_erroneusnickname',
+      'type': 'error'
+   },
+   '433': {
+      'name': 'err_nicknameinuse',
+      'type': 'error'
+   },
+   '436': {
+      'name': 'err_nickcollision',
+      'type': 'error'
+   },
+   '441': {
+      'name': 'err_usernotinchannel',
+      'type': 'error'
+   },
+   '442': {
+      'name': 'err_notonchannel',
+      'type': 'error'
+   },
+   '443': {
+      'name': 'err_useronchannel',
+      'type': 'error'
+   },
+   '444': {
+      'name': 'err_nologin',
+      'type': 'error'
+   },
+   '445': {
+      'name': 'err_summondisabled',
+      'type': 'error'
+   },
+   '446': {
+      'name': 'err_usersdisabled',
+      'type': 'error'
+   },
+   '451': {
+      'name': 'err_notregistered',
+      'type': 'error'
+   },
+   '461': {
+      'name': 'err_needmoreparams',
+      'type': 'error'
+   },
+   '462': {
+      'name': 'err_alreadyregistred',
+      'type': 'error'
+   },
+   '463': {
+      'name': 'err_nopermforhost',
+      'type': 'error'
+   },
+   '464': {
+      'name': 'err_passwdmismatch',
+      'type': 'error'
+   },
+   '465': {
+      'name': 'err_yourebannedcreep',
+      'type': 'error'
+   },
+   '467': {
+      'name': 'err_keyset',
+      'type': 'error'
+   },
+   '471': {
+      'name': 'err_channelisfull',
+      'type': 'error'
+   },
+   '472': {
+      'name': 'err_unknownmode',
+      'type': 'error'
+   },
+   '473': {
+      'name': 'err_inviteonlychan',
+      'type': 'error'
+   },
+   '474': {
+      'name': 'err_bannedfromchan',
+      'type': 'error'
+   },
+   '475': {
+      'name': 'err_badchannelkey',
+      'type': 'error'
+   },
+   '481': {
+      'name': 'err_noprivileges',
+      'type': 'error'
+   },
+   '482': {
+      'name': 'err_chanoprivsneeded',
+      'type': 'error'
+   },
+   '483': {
+      'name': 'err_cantkillserver',
+      'type': 'error'
+   },
+   '491': {
+      'name': 'err_nooperhost',
+      'type': 'error'
+   },
+   '501': {
+      'name': 'err_umodeunknownflag',
+      'type': 'error'
+   },
+   '502': {
+      'name': 'err_usersdontmatch',
+      'type': 'error'
    }
 }; // }}}

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -24,7 +24,7 @@ var codes = {
 exports.codes = codes;
 
 function wrap(color, text, resetColor) {
-    if(codes[color]) {
+    if (codes[color]) {
         text = codes[color] + text;
         text += (codes[resetColor]) ? codes[resetColor] : codes.reset;
     }

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -19,7 +19,7 @@ var codes = {
     bold: '\u000216',
     underline: '\u001f17',
 
-    reset: '\u000f',
+    reset: '\u000f'
 };
 exports.codes = codes;
 

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -23,10 +23,10 @@ var codes = {
 };
 exports.codes = codes;
 
-function wrap(color, text, reset_color) {
+function wrap(color, text, resetColor) {
     if(codes[color]) {
         text = codes[color] + text;
-        text += (codes[reset_color]) ? codes[reset_color] : codes.reset;
+        text += (codes[resetColor]) ? codes[resetColor] : codes.reset;
     }
     return text;
 }

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -15,10 +15,10 @@ var codes = {
     light_magenta: '\u000313',
     gray: '\u000314',
     light_gray: '\u000315',
-    
+
     bold: '\u000216',
     underline: '\u001f17',
-    
+
     reset: '\u000f',
 };
 exports.codes = codes;
@@ -26,9 +26,8 @@ exports.codes = codes;
 function wrap(color, text, reset_color) {
     if(codes[color]) {
         text = codes[color] + text;
-        text += (codes[reset_color]) ? codes[reset_color] : codes['reset'];
+        text += (codes[reset_color]) ? codes[reset_color] : codes.reset;
     }
     return text;
-};
+}
 exports.wrap = wrap;
-

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -116,7 +116,7 @@ function Client(server, nick, opt) {
                 message.args.forEach(function(arg) {
                     var match;
                     match = arg.match(/([A-Z]+)=(.*)/);
-                    if ( match ) {
+                    if (match) {
                         var param = match[1];
                         var value = match[2];
                         switch(param) {
@@ -159,7 +159,7 @@ function Client(server, nick, opt) {
                                 break;
                             case 'PREFIX':
                                 match = value.match(/\((.*?)\)(.*)/);
-                                if ( match ) {
+                                if (match) {
                                     match[1] = match[1].split('');
                                     match[2] = match[2].split('');
                                     while ( match[1].length ) {
@@ -197,7 +197,7 @@ function Client(server, nick, opt) {
                 // Random welcome crap, ignoring
                 break;
             case "err_nicknameinuse":
-                if ( typeof(self.opt.nickMod) == 'undefined' )
+                if (typeof(self.opt.nickMod) == 'undefined')
                     self.opt.nickMod = 0;
                 self.opt.nickMod++;
                 self.send("NICK", self.opt.nick + self.opt.nickMod);
@@ -223,26 +223,26 @@ function Client(server, nick, opt) {
                 }
                 self.emit('notice', from, to, text, message);
 
-                if ( self.opt.debug && to == self.nick )
+                if (self.opt.debug && to == self.nick)
                     util.log('GOT NOTICE from ' + (from?'"'+from+'"':'the server') + ': "' + text + '"');
                 break;
             case "MODE":
-                if ( self.opt.debug )
+                if (self.opt.debug)
                     util.log("MODE: " + message.args[0] + " sets mode: " + message.args[1]);
 
                 channel = self.chanData(message.args[0]);
-                if ( !channel ) break;
+                if (!channel) break;
                 var modeList = message.args[1].split('');
                 var adding = true;
                 var modeArgs = message.args.slice(2);
                 modeList.forEach(function(mode) {
-                    if ( mode == '+' ) { adding = true; return; }
-                    if ( mode == '-' ) { adding = false; return; }
-                    if ( mode in self.prefixForMode ) {
+                    if (mode == '+') { adding = true; return; }
+                    if (mode == '-') { adding = false; return; }
+                    if (mode in self.prefixForMode) {
                         // channel user modes
                         var user = modeArgs.shift();
-                        if ( adding ) {
-                            if ( channel.users[user].indexOf(self.prefixForMode[mode]) === -1 )
+                        if (adding) {
+                            if (channel.users[user].indexOf(self.prefixForMode[mode]) === -1)
                                 channel.users[user] += self.prefixForMode[mode];
 
                             self.emit('+mode', message.args[0], message.nick, mode, user, message);
@@ -255,14 +255,14 @@ function Client(server, nick, opt) {
                     else {
                         var modeArg;
                         // channel modes
-                        if ( mode.match(/^[bkl]$/) ) {
+                        if (mode.match(/^[bkl]$/)) {
                             modeArg = modeArgs.shift();
-                            if ( modeArg.length === 0 )
+                            if (modeArg.length === 0)
                                 modeArg = undefined;
                         }
                         // TODO - deal nicely with channel modes that take args
-                        if ( adding ) {
-                            if ( channel.mode.indexOf(mode) === -1 )
+                        if (adding) {
+                            if (channel.mode.indexOf(mode) === -1)
                                 channel.mode += mode;
 
                             self.emit('+mode', message.args[0], message.nick, mode, modeArg, message);
@@ -275,11 +275,11 @@ function Client(server, nick, opt) {
                 });
                 break;
             case "NICK":
-                if ( message.nick == self.nick )
+                if (message.nick == self.nick)
                     // the user just changed their own nick
                     self.nick = message.args[0];
 
-                if ( self.opt.debug )
+                if (self.opt.debug)
                     util.log("NICK: " + message.nick + " changes nick to " + message.args[0]);
 
                 channels = [];
@@ -309,11 +309,11 @@ function Client(server, nick, opt) {
             case "rpl_namreply":
                 channel = self.chanData(message.args[2]);
                 var users = message.args[3].trim().split(/ +/);
-                if ( channel ) {
+                if (channel) {
                     users.forEach(function (user) {
                         var match = user.match(/^(.)(.*)$/);
-                        if ( match ) {
-                            if ( match[1] in self.modeForPrefix ) {
+                        if (match) {
+                            if (match[1] in self.modeForPrefix) {
                                 channel.users[match[2]] = match[1];
                             }
                             else {
@@ -325,7 +325,7 @@ function Client(server, nick, opt) {
                 break;
             case "rpl_endofnames":
                 channel = self.chanData(message.args[1]);
-                if ( channel ) {
+                if (channel) {
                     self.emit('names', message.args[1], channel.users);
                     self.emit('names' + message.args[1], channel.users);
                     self.send('MODE', message.args[1]);
@@ -333,7 +333,7 @@ function Client(server, nick, opt) {
                 break;
             case "rpl_topic":
                 channel = self.chanData(message.args[1]);
-                if ( channel ) {
+                if (channel) {
                     channel.topic = message.args[2];
                 }
                 break;
@@ -384,7 +384,7 @@ function Client(server, nick, opt) {
                 break;
             case "rpl_topicwhotime":
                 channel = self.chanData(message.args[1]);
-                if ( channel ) {
+                if (channel) {
                     channel.topicBy = message.args[2];
                     // channel, topic, nick
                     self.emit('topic', message.args[1], channel.topic, channel.topicBy, message);
@@ -395,26 +395,26 @@ function Client(server, nick, opt) {
                 self.emit('topic', message.args[0], message.args[1], message.nick, message);
 
                 channel = self.chanData(message.args[0]);
-                if ( channel ) {
+                if (channel) {
                     channel.topic = message.args[1];
                     channel.topicBy = message.nick;
                 }
                 break;
             case "rpl_channelmodeis":
                 channel = self.chanData(message.args[1]);
-                if ( channel ) {
+                if (channel) {
                     channel.mode = message.args[2];
                 }
                 break;
             case "rpl_creationtime":
                 channel = self.chanData(message.args[1]);
-                if ( channel ) {
+                if (channel) {
                     channel.created = message.args[2];
                 }
                 break;
             case "JOIN":
                 // channel, who
-                if ( self.nick == message.nick ) {
+                if (self.nick == message.nick) {
                     self.chanData(message.args[0], true);
                 }
                 else {
@@ -425,7 +425,7 @@ function Client(server, nick, opt) {
                 }
                 self.emit('join', message.args[0], message.nick, message);
                 self.emit('join' + message.args[0], message.nick, message);
-                if ( message.args[0] != message.args[0].toLowerCase() ) {
+                if (message.args[0] != message.args[0].toLowerCase()) {
                     self.emit('join' + message.args[0].toLowerCase(), message.nick, message);
                 }
                 break;
@@ -433,10 +433,10 @@ function Client(server, nick, opt) {
                 // channel, who, reason
                 self.emit('part', message.args[0], message.nick, message.args[1], message);
                 self.emit('part' + message.args[0], message.nick, message.args[1], message);
-                if ( message.args[0] != message.args[0].toLowerCase() ) {
+                if (message.args[0] != message.args[0].toLowerCase()) {
                     self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
                 }
-                if ( self.nick == message.nick ) {
+                if (self.nick == message.nick) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
                 }
@@ -451,12 +451,12 @@ function Client(server, nick, opt) {
                 // channel, who, by, reason
                 self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
                 self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
-                if ( message.args[0] != message.args[0].toLowerCase() ) {
+                if (message.args[0] != message.args[0].toLowerCase()) {
                     self.emit('kick' + message.args[0].toLowerCase(),
                               message.args[1], message.nick, message.args[2], message);
                 }
 
-                if ( self.nick == message.args[1] ) {
+                if (self.nick == message.args[1]) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
                 }
@@ -486,16 +486,16 @@ function Client(server, nick, opt) {
                     break;
                 }
                 self.emit('message', from, to, text, message);
-                if ( self.supported.channel.types.indexOf(to.charAt(0)) !== -1 ) {
+                if (self.supported.channel.types.indexOf(to.charAt(0)) !== -1) {
                     self.emit('message#', from, to, text, message);
                     self.emit('message' + to, from, text, message);
-                    if ( to != to.toLowerCase() ) {
+                    if (to != to.toLowerCase()) {
                         self.emit('message' + to.toLowerCase(), from, text, message);
                     }
                 }
-                if ( to == self.nick ) self.emit('pm', from, text, message);
+                if (to == self.nick) self.emit('pm', from, text, message);
 
-                if ( self.opt.debug && to == self.nick )
+                if (self.opt.debug && to == self.nick)
                     util.log('GOT MESSAGE from ' + from + ': ' + text);
                 break;
             case "INVITE":
@@ -505,9 +505,9 @@ function Client(server, nick, opt) {
                 self.emit('invite', channel, from, message);
                 break;
             case "QUIT":
-                if ( self.opt.debug )
+                if (self.opt.debug)
                     util.log("QUIT: " + message.prefix + " " + message.args.join(" "));
-                if ( self.nick == message.nick ) {
+                if (self.nick == message.nick) {
                     // TODO handle?
                     break;
                 }
@@ -528,13 +528,13 @@ function Client(server, nick, opt) {
 
             // for sasl
             case "CAP":
-                if ( message.args[0] === '*' &&
+                if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ' ) // there's a space after sasl
+                     message.args[2] === 'sasl ') // there's a space after sasl
                     self.send("AUTHENTICATE", "PLAIN");
                 break;
             case "AUTHENTICATE":
-                if ( message.args[0] === '+' ) self.send("AUTHENTICATE",
+                if (message.args[0] === '+') self.send( "AUTHENTICATE",
                     new Buffer(
                         self.opt.nick + '\0' +
                         self.opt.userName + '\0' +
@@ -546,24 +546,24 @@ function Client(server, nick, opt) {
                 break;
 
             case "err_umodeunknownflag":
-                if ( self.opt.showErrors )
+                if (self.opt.showErrors)
                     util.log("\u001b[01;31mERROR: " + util.inspect(message) + "\u001b[0m");
                 break;
 
             case "err_erroneusnickname":
-                if ( self.opt.showErrors )
+                if (self.opt.showErrors)
                     util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
                 self.emit('error', message);
                 break;
 
             default:
-                if ( message.commandType == 'error' ) {
+                if (message.commandType == 'error') {
                     self.emit('error', message);
-                    if ( self.opt.showErrors )
+                    if (self.opt.showErrors)
                         util.log("\u001b[01;31mERROR: " + util.inspect(message) + "\u001b[0m");
                 }
                 else {
-                    if ( self.opt.debug )
+                    if (self.opt.debug)
                         util.log("\u001b[01;31mUnhandled message: " + util.inspect(message) + "\u001b[0m");
                 break;
                 }
@@ -571,7 +571,7 @@ function Client(server, nick, opt) {
     }); // }}}
 
     self.addListener('kick', function(channel, who, by, reason) {
-        if ( self.opt.autoRejoin )
+        if (self.opt.autoRejoin)
             self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
     });
     self.addListener('motd', function (motd) {
@@ -592,7 +592,7 @@ Client.prototype.chans = {};
 Client.prototype._whoisData = {};
 Client.prototype.chanData = function( name, create ) { // {{{
     var key = name.toLowerCase();
-    if ( create ) {
+    if (create) {
         this.chans[key] = this.chans[key] || {
             key: key,
             serverName: name,
@@ -604,7 +604,7 @@ Client.prototype.chanData = function( name, create ) { // {{{
     return this.chans[key];
 }; // }}}
 Client.prototype.connect = function ( retryCount, callback ) { // {{{
-    if ( typeof(retryCount) === 'function' ) {
+    if (typeof(retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
     }
@@ -633,14 +633,14 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
                    self.conn.authorizationError === 'CERT_HAS_EXPIRED')) {
               // authorization successful
               self.conn.setEncoding('utf-8');
-                if ( self.opt.certExpired &&
-                   self.conn.authorizationError === 'CERT_HAS_EXPIRED' ) {
+                if (self.opt.certExpired &&
+                   self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
                      util.log('Connecting to server with expired certificate');
                 }
-                if ( self.opt.password !==  null ) {
-                    self.send( "PASS", self.opt.password );
+                if (self.opt.password !==  null) {
+                    self.send("PASS", self.opt.password);
                 }
-                if ( self.opt.debug )
+                if (self.opt.debug)
                     util.log('Sending irc NICK/USER');
                 self.send("NICK", self.opt.nick);
                 self.nick = self.opt.nick;
@@ -658,10 +658,10 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
     self.conn.addListener("connect", function () {
-        if ( self.opt.sasl ) {
+        if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send("CAP REQ", "sasl");
-        } else if ( self.opt.password !==  null ) {
+        } else if (self.opt.password !==  null) {
             self.send( "PASS", self.opt.password );
         }
         self.send("NICK", self.opt.nick);
@@ -679,33 +679,33 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
             try {
                 self.emit('raw', message);
             } catch ( err ) {
-                if ( !self.conn.requestedDisconnect ) {
+                if (!self.conn.requestedDisconnect) {
                     throw err;
                 }
             }
         });
     });
     self.conn.addListener("end", function() {
-        if ( self.opt.debug )
+        if (self.opt.debug)
             util.log('Connection got "end" event');
     });
     self.conn.addListener("close", function() {
-        if ( self.opt.debug )
+        if (self.opt.debug)
             util.log('Connection got "close" event');
-        if ( self.conn.requestedDisconnect )
+        if (self.conn.requestedDisconnect)
             return;
-        if ( self.opt.debug )
+        if (self.opt.debug)
             util.log('Disconnected: reconnecting');
-        if ( self.opt.retryCount !== null && retryCount >= self.opt.retryCount ) {
-            if ( self.opt.debug ) {
-                util.log( 'Maximum retry count (' + self.opt.retryCount + ') reached. Aborting' );
+        if (self.opt.retryCount !== null && retryCount >= self.opt.retryCount) {
+            if (self.opt.debug) {
+                util.log('Maximum retry count (' + self.opt.retryCount + ') reached. Aborting');
             }
-            self.emit( 'abort', self.opt.retryCount );
+            self.emit('abort', self.opt.retryCount);
             return;
         }
 
-        if ( self.opt.debug ) {
-            util.log( 'Waiting ' + self.opt.retryDelay + 'ms before retrying' );
+        if (self.opt.debug) {
+            util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
         }
         setTimeout( function() {
             self.connect( retryCount + 1 );
@@ -716,13 +716,13 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     });
 }; // }}}
 Client.prototype.disconnect = function ( message, callback ) { // {{{
-    if ( typeof(message) === 'function' ) {
+    if (typeof(message) === 'function') {
         callback = message;
         message = undefined;
     }
     message = message || "node-irc says goodbye";
     var self = this;
-    if ( self.conn.readyState == 'open' ) {
+    if (self.conn.readyState == 'open') {
         var sendFunction;
         if (self.opt.floodProtection) {
             sendFunction = self._sendImmediate;
@@ -743,14 +743,14 @@ Client.prototype.send = function(command) { // {{{
 
     // Note that the command arg is included in the args array as the first element
 
-    if ( args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === "" ) {
+    if (args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === "") {
         args[args.length-1] = ":" + args[args.length-1];
     }
 
-    if ( this.opt.debug )
+    if (this.opt.debug)
         util.log('SEND: ' + args.join(" "));
 
-    if ( ! this.conn.requestedDisconnect ) {
+    if (!this.conn.requestedDisconnect) {
         this.conn.write(args.join(" ") + "\r\n");
     }
 }; // }}}
@@ -800,18 +800,18 @@ Client.prototype.join = function(channel, callback) { // {{{
             this.opt.channels.push(channel);
         }
 
-        if ( typeof(callback) == 'function' ) {
+        if (typeof(callback) == 'function') {
             return callback.apply(this, arguments);
         }
     });
     this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
 }; // }}}
 Client.prototype.part = function(channel, message, callback) { // {{{
-    if ( typeof(message) === 'function' ) {
+    if (typeof(message) === 'function') {
         callback = message;
         message = undefined;
     }
-    if ( typeof(callback) == 'function' ) {
+    if (typeof(callback) == 'function') {
         this.once('part' + channel, callback);
     }
 
@@ -856,9 +856,9 @@ Client.prototype.notice = function(target, text) { // {{{
     this.send('NOTICE', target, text);
 }; // }}}
 Client.prototype.whois = function(nick, callback) { // {{{
-    if ( typeof callback === 'function' ) {
+    if (typeof callback === 'function') {
         var callbackWrapper = function(info) {
-            if ( info.nick == nick ) {
+            if (info.nick == nick) {
                 this.removeListener('whois', callbackWrapper);
                 return callback.apply(this, arguments);
             }
@@ -873,7 +873,7 @@ Client.prototype.list = function() { // {{{
     this.send.apply(this, args);
 }; // }}}
 Client.prototype._addWhoisData = function(nick, key, value, onlyIfExists) { // {{{
-    if ( onlyIfExists && !this._whoisData[nick] ) return;
+    if (onlyIfExists && !this._whoisData[nick]) return;
     this._whoisData[nick] = this._whoisData[nick] || {nick: nick};
     this._whoisData[nick][key] = value;
 }; // }}}
@@ -917,11 +917,11 @@ function parseMessage(line, stripColors) { // {{{
 
     // Parse prefix
     match = line.match(/^:([^ ]+) +/);
-    if ( match ) {
+    if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
         match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
-        if ( match ) {
+        if (match) {
             message.nick = match[1];
             message.user = match[3];
             message.host = match[4];
@@ -938,7 +938,7 @@ function parseMessage(line, stripColors) { // {{{
     message.commandType = 'normal';
     line = line.replace(/^[^ ]+ +/, '');
 
-    if ( replyFor[message.rawCommand] ) {
+    if (replyFor[message.rawCommand]) {
         message.command     = replyFor[message.rawCommand].name;
         message.commandType = replyFor[message.rawCommand].type;
     }
@@ -947,7 +947,7 @@ function parseMessage(line, stripColors) { // {{{
     var middle, trailing;
 
     // Parse parameters
-    if ( line.search(/^:|\s+:/) != -1 ) {
+    if (line.search(/^:|\s+:/) != -1) {
         match = line.match(/(.*?)(?:^:|\s+:)(.*)/);
         middle = match[1].trimRight();
         trailing = match[2];
@@ -956,10 +956,10 @@ function parseMessage(line, stripColors) { // {{{
         middle = line;
     }
 
-    if ( middle.length )
+    if (middle.length)
         message.args = middle.split(/ +/);
 
-    if ( typeof(trailing) != 'undefined' && trailing.length )
+    if (typeof(trailing) != 'undefined' && trailing.length)
         message.args.push(trailing);
 
     return message;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -128,7 +128,7 @@ function Client(server, nick, opt) {
                                 break;
                             case 'CHANMODES':
                                 value = value.split(',');
-                                var type = ['a','b','c','d'];
+                                var type = ['a', 'b', 'c', 'd'];
                                 for (var i = 0; i < type.length; i++) {
                                     self.supported.channel.modes[type[i]] += value[i];
                                 }
@@ -749,8 +749,8 @@ Client.prototype.send = function(command) { // {{{
 
     // Note that the command arg is included in the args array as the first element
 
-    if (args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === '') {
-        args[args.length-1] = ':' + args[args.length-1];
+    if (args[args.length - 1].match(/\s/) || args[args.length - 1].match(/^:/) || args[args.length - 1] === '') {
+        args[args.length - 1] = ':' + args[args.length - 1];
     }
 
     if (this.opt.debug)
@@ -895,7 +895,7 @@ Client.prototype._handleCTCP = function(from, to, text, type, message) {
     text = text.slice(0, text.indexOf('\u0001'));
     var parts = text.split(' ');
     this.emit('ctcp', from, to, text, type, message);
-    this.emit('ctcp-'+type, from, to, text, message);
+    this.emit('ctcp-' + type, from, to, text, message);
     if (type === 'privmsg' && text === 'VERSION')
         this.emit('ctcp-version', from, to, message);
     if (parts[0] === 'ACTION' && parts.length > 1)
@@ -904,7 +904,7 @@ Client.prototype._handleCTCP = function(from, to, text, type, message) {
         this.ctcp(from, 'notice', text);
 };
 Client.prototype.ctcp = function(to, type, text) {
-    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1'+text+'\1');
+    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1' + text + '\1');
 };
 
 /*

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -94,6 +94,13 @@ function Client(server, nick, opt) {
     }
 
     self.addListener("raw", function (message) { // {{{
+        var channels = [],
+            channel,
+            nick,
+            from,
+            text,
+            to;
+
         switch ( message.command ) {
             case "rpl_welcome":
                 // Set nick to whatever the server decided it really is
@@ -108,7 +115,8 @@ function Client(server, nick, opt) {
             case "rpl_isupport":
                 message.args.forEach(function(arg) {
                     var match;
-                    if ( match = arg.match(/([A-Z]+)=(.*)/) ) {
+                    match = arg.match(/([A-Z]+)=(.*)/);
+                    if ( match ) {
                         var param = match[1];
                         var value = match[2];
                         switch(param) {
@@ -120,7 +128,7 @@ function Client(server, nick, opt) {
                                 break;
                             case 'CHANMODES':
                                 value = value.split(',');
-                                var type = ['a','b','c','d']
+                                var type = ['a','b','c','d'];
                                 for (var i = 0; i < type.length; i++) {
                                     self.supported.channel.modes[type[i]] += value[i];
                                 }
@@ -150,7 +158,8 @@ function Client(server, nick, opt) {
                                 self.supported.nicklength = parseInt(value);
                                 break;
                             case 'PREFIX':
-                                if (match = value.match(/\((.*?)\)(.*)/)) {
+                                match = value.match(/\((.*?)\)(.*)/);
+                                if ( match ) {
                                     match[1] = match[1].split('');
                                     match[2] = match[2].split('');
                                     while ( match[1].length ) {
@@ -202,12 +211,12 @@ function Client(server, nick, opt) {
                 self.emit("pong", message.args[0]);
                 break;
             case "NOTICE":
-                var from = message.nick;
-                var to   = message.args[0];
+                from = message.nick;
+                to = message.args[0];
                 if (!to) {
-                    to   = null;
+                    to = null;
                 }
-                var text = message.args[1] || '';
+                text = message.args[1] || '';
                 if (text[0] === '\u0001' && text.lastIndexOf('\u0001') > 0) {
                     self._handleCTCP(from, to, text, 'notice', message);
                     break;
@@ -221,7 +230,7 @@ function Client(server, nick, opt) {
                 if ( self.opt.debug )
                     util.log("MODE: " + message.args[0] + " sets mode: " + message.args[1]);
 
-                var channel = self.chanData(message.args[0]);
+                channel = self.chanData(message.args[0]);
                 if ( !channel ) break;
                 var modeList = message.args[1].split('');
                 var adding = true;
@@ -273,7 +282,7 @@ function Client(server, nick, opt) {
                 if ( self.opt.debug )
                     util.log("NICK: " + message.nick + " changes nick to " + message.args[0]);
 
-                var channels = [];
+                channels = [];
 
                 // TODO better way of finding what channels a user is in?
                 Object.keys(self.chans).forEach(function(channame) {
@@ -298,7 +307,7 @@ function Client(server, nick, opt) {
                 self.emit('motd', self.motd);
                 break;
             case "rpl_namreply":
-                var channel = self.chanData(message.args[2]);
+                channel = self.chanData(message.args[2]);
                 var users = message.args[3].trim().split(/ +/);
                 if ( channel ) {
                     users.forEach(function (user) {
@@ -315,7 +324,7 @@ function Client(server, nick, opt) {
                 }
                 break;
             case "rpl_endofnames":
-                var channel = self.chanData(message.args[1]);
+                channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     self.emit('names', message.args[1], channel.users);
                     self.emit('names' + message.args[1], channel.users);
@@ -323,7 +332,7 @@ function Client(server, nick, opt) {
                 }
                 break;
             case "rpl_topic":
-                var channel = self.chanData(message.args[1]);
+                channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.topic = message.args[2];
                 }
@@ -340,7 +349,8 @@ function Client(server, nick, opt) {
                 self._addWhoisData(message.args[1], 'idle', message.args[2]);
                 break;
             case "rpl_whoischannels":
-                self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/)); // TODO - clean this up?
+               // TODO - clean this up?
+                self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
                 break;
             case "rpl_whoisserver":
                 self._addWhoisData(message.args[1], 'server', message.args[2]);
@@ -361,7 +371,7 @@ function Client(server, nick, opt) {
                 self.emit('channellist_start');
                 break;
             case "rpl_list":
-                var channel = {
+                channel = {
                     name: message.args[1],
                     users: message.args[2],
                     topic: message.args[3],
@@ -373,7 +383,7 @@ function Client(server, nick, opt) {
                 self.emit('channellist', self.channellist);
                 break;
             case "rpl_topicwhotime":
-                var channel = self.chanData(message.args[1]);
+                channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.topicBy = message.args[2];
                     // channel, topic, nick
@@ -384,20 +394,20 @@ function Client(server, nick, opt) {
                 // channel, topic, nick
                 self.emit('topic', message.args[0], message.args[1], message.nick, message);
 
-                var channel = self.chanData(message.args[0]);
+                channel = self.chanData(message.args[0]);
                 if ( channel ) {
                     channel.topic = message.args[1];
                     channel.topicBy = message.nick;
                 }
                 break;
             case "rpl_channelmodeis":
-                var channel = self.chanData(message.args[1]);
+                channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.mode = message.args[2];
                 }
                 break;
             case "rpl_creationtime":
-                var channel = self.chanData(message.args[1]);
+                channel = self.chanData(message.args[1]);
                 if ( channel ) {
                     channel.created = message.args[2];
                 }
@@ -408,7 +418,7 @@ function Client(server, nick, opt) {
                     self.chanData(message.args[0], true);
                 }
                 else {
-                    var channel = self.chanData(message.args[0]);
+                    channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         channel.users[message.nick] = '';
                     }
@@ -427,11 +437,11 @@ function Client(server, nick, opt) {
                     self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
                 }
                 if ( self.nick == message.nick ) {
-                    var channel = self.chanData(message.args[0]);
+                    channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
                 }
                 else {
-                    var channel = self.chanData(message.args[0]);
+                    channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         delete channel.users[message.nick];
                     }
@@ -442,23 +452,24 @@ function Client(server, nick, opt) {
                 self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
                 self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
                 if ( message.args[0] != message.args[0].toLowerCase() ) {
-                    self.emit('kick' + message.args[0].toLowerCase(), message.args[1], message.nick, message.args[2], message);
+                    self.emit('kick' + message.args[0].toLowerCase(),
+                              message.args[1], message.nick, message.args[2], message);
                 }
 
                 if ( self.nick == message.args[1] ) {
-                    var channel = self.chanData(message.args[0]);
+                    channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
                 }
                 else {
-                    var channel = self.chanData(message.args[0]);
+                    channel = self.chanData(message.args[0]);
                     if (channel && channel.users) {
                         delete channel.users[message.args[1]];
                     }
                 }
                 break;
             case "KILL":
-                var nick = message.args[0];
-                var channels = [];
+                nick = message.args[0];
+                channels = [];
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
                     channels.push(channame);
@@ -467,9 +478,9 @@ function Client(server, nick, opt) {
                 self.emit('kill', nick, message.args[1], channels, message);
                 break;
             case "PRIVMSG":
-                var from = message.nick;
-                var to   = message.args[0];
-                var text = message.args[1] || '';
+                from = message.nick;
+                to = message.args[0];
+                text = message.args[1] || '';
                 if (text[0] === '\u0001' && text.lastIndexOf('\u0001') > 0) {
                     self._handleCTCP(from, to, text, 'privmsg', message);
                     break;
@@ -488,9 +499,9 @@ function Client(server, nick, opt) {
                     util.log('GOT MESSAGE from ' + from + ': ' + text);
                 break;
             case "INVITE":
-                var from = message.nick;
-                var to   = message.args[0];
-                var channel = message.args[1];
+                from = message.nick;
+                to = message.args[0];
+                channel = message.args[1];
                 self.emit('invite', channel, from, message);
                 break;
             case "QUIT":
@@ -502,7 +513,7 @@ function Client(server, nick, opt) {
                 }
                 // handle other people quitting
 
-                var channels = [];
+                channels = [];
 
                 // TODO better way of finding what channels a user is in?
                 Object.keys(self.chans).forEach(function(channame) {
@@ -591,7 +602,7 @@ Client.prototype.chanData = function( name, create ) { // {{{
     }
 
     return this.chans[key];
-} // }}}
+}; // }}}
 Client.prototype.connect = function ( retryCount, callback ) { // {{{
     if ( typeof(retryCount) === 'function' ) {
         callback = retryCount;
@@ -759,11 +770,11 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
 
     this._sendImmediate = function () {
         origSend.apply(self, arguments);
-    }
+    };
 
     this._clearCmdQueue = function () {
         cmdQueue = [];
-    }
+    };
 
     dequeue = function() {
         var args = cmdQueue.shift();
@@ -794,7 +805,7 @@ Client.prototype.join = function(channel, callback) { // {{{
         }
     });
     this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
-} // }}}
+}; // }}}
 Client.prototype.part = function(channel, message, callback) { // {{{
     if ( typeof(message) === 'function' ) {
         callback = message;
@@ -815,21 +826,22 @@ Client.prototype.part = function(channel, message, callback) { // {{{
     } else {
     	this.send('PART', channel);
     }
-} // }}}
+}; // }}}
 Client.prototype.say = function(target, text) { // {{{
     var self = this;
     if (typeof text !== 'undefined') {
         text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;
         }).forEach(function(line) {
-            var r = new RegExp(".{1," + self.opt.messageSplit + "}", "g");
-            while ((messagePart = r.exec(line)) != null) {
+            var r = new RegExp(".{1," + self.opt.messageSplit + "}", "g"),
+                messagePart;
+            while ((messagePart = r.exec(line)) !== null) {
                 self.send('PRIVMSG', target, messagePart[0]);
                 self.emit('selfMessage', target, messagePart[0]);
             }
         });
     }
-} // }}}
+}; // }}}
 Client.prototype.action = function(channel, text) { // {{{
     var self = this;
     if (typeof text !== 'undefined') {
@@ -839,10 +851,10 @@ Client.prototype.action = function(channel, text) { // {{{
             self.say(channel, '\u0001ACTION ' + line + '\u0001');
         });
     }
-} // }}}
+}; // }}}
 Client.prototype.notice = function(target, text) { // {{{
     this.send('NOTICE', target, text);
-} // }}}
+}; // }}}
 Client.prototype.whois = function(nick, callback) { // {{{
     if ( typeof callback === 'function' ) {
         var callbackWrapper = function(info) {
@@ -854,40 +866,40 @@ Client.prototype.whois = function(nick, callback) { // {{{
         this.addListener('whois', callbackWrapper);
     }
     this.send('WHOIS', nick);
-} // }}}
+}; // }}}
 Client.prototype.list = function() { // {{{
     var args = Array.prototype.slice.call(arguments, 0);
     args.unshift('LIST');
     this.send.apply(this, args);
-} // }}}
+}; // }}}
 Client.prototype._addWhoisData = function(nick, key, value, onlyIfExists) { // {{{
     if ( onlyIfExists && !this._whoisData[nick] ) return;
     this._whoisData[nick] = this._whoisData[nick] || {nick: nick};
     this._whoisData[nick][key] = value;
-} // }}}
+}; // }}}
 Client.prototype._clearWhoisData = function(nick) { // {{{
     // Ensure that at least the nick exists before trying to return
     this._addWhoisData(nick, 'nick', nick);
     var data = this._whoisData[nick];
     delete this._whoisData[nick];
     return data;
-} // }}}
+}; // }}}
 Client.prototype._handleCTCP = function(from, to, text, type, message) {
-    text = text.slice(1)
-    text = text.slice(0, text.indexOf('\u0001'))
-    var parts = text.split(' ')
-    this.emit('ctcp', from, to, text, type, message)
-    this.emit('ctcp-'+type, from, to, text, message)
+    text = text.slice(1);
+    text = text.slice(0, text.indexOf('\u0001'));
+    var parts = text.split(' ');
+    this.emit('ctcp', from, to, text, type, message);
+    this.emit('ctcp-'+type, from, to, text, message);
     if (type === 'privmsg' && text === 'VERSION')
-        this.emit('ctcp-version', from, to, message)
+        this.emit('ctcp-version', from, to, message);
     if (parts[0] === 'ACTION' && parts.length > 1)
-        this.emit('action', from, to, parts.slice(1).join(' '), message)
+        this.emit('action', from, to, parts.slice(1).join(' '), message);
     if (parts[0] === 'PING' && type === 'privmsg' && parts.length > 1)
-        this.ctcp(from, 'notice', text)
-}
+        this.ctcp(from, 'notice', text);
+};
 Client.prototype.ctcp = function(to, type, text) {
     return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1'+text+'\1');
-}
+};
 
 /*
  * parseMessage(line, stripColors)
@@ -904,10 +916,12 @@ function parseMessage(line, stripColors) { // {{{
     }
 
     // Parse prefix
-    if ( match = line.match(/^:([^ ]+) +/) ) {
+    match = line.match(/^:([^ ]+) +/);
+    if ( match ) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        if ( match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/) ) {
+        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        if ( match ) {
             message.nick = match[1];
             message.user = match[3];
             message.host = match[4];

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -50,7 +50,7 @@ function Client(server, nick, opt) {
         floodProtectionDelay: 1000,
         sasl: false,
         stripColors: false,
-        channelPrefixes: "&#",
+        channelPrefixes: '&#',
         messageSplit: 512
     };
 
@@ -93,7 +93,7 @@ function Client(server, nick, opt) {
       self.connect();
     }
 
-    self.addListener("raw", function(message) { // {{{
+    self.addListener('raw', function(message) { // {{{
         var channels = [],
             channel,
             nick,
@@ -102,17 +102,17 @@ function Client(server, nick, opt) {
             to;
 
         switch ( message.command ) {
-            case "rpl_welcome":
+            case 'rpl_welcome':
                 // Set nick to whatever the server decided it really is
                 // (normally this is because you chose something too long and
                 // the server has shortened it
                 self.nick = message.args[0];
                 self.emit('registered', message);
                 break;
-            case "rpl_myinfo":
+            case 'rpl_myinfo':
                 self.supported.usermodes = message.args[3];
                 break;
-            case "rpl_isupport":
+            case 'rpl_isupport':
                 message.args.forEach(function(arg) {
                     var match;
                     match = arg.match(/([A-Z]+)=(.*)/);
@@ -185,32 +185,32 @@ function Client(server, nick, opt) {
                     }
                 });
                 break;
-            case "rpl_yourhost":
-            case "rpl_created":
-            case "rpl_luserclient":
-            case "rpl_luserop":
-            case "rpl_luserchannels":
-            case "rpl_luserme":
-            case "rpl_localusers":
-            case "rpl_globalusers":
-            case "rpl_statsconn":
+            case 'rpl_yourhost':
+            case 'rpl_created':
+            case 'rpl_luserclient':
+            case 'rpl_luserop':
+            case 'rpl_luserchannels':
+            case 'rpl_luserme':
+            case 'rpl_localusers':
+            case 'rpl_globalusers':
+            case 'rpl_statsconn':
                 // Random welcome crap, ignoring
                 break;
-            case "err_nicknameinuse":
+            case 'err_nicknameinuse':
                 if (typeof(self.opt.nickMod) == 'undefined')
                     self.opt.nickMod = 0;
                 self.opt.nickMod++;
-                self.send("NICK", self.opt.nick + self.opt.nickMod);
+                self.send('NICK', self.opt.nick + self.opt.nickMod);
                 self.nick = self.opt.nick + self.opt.nickMod;
                 break;
-            case "PING":
-                self.send("PONG", message.args[0]);
+            case 'PING':
+                self.send('PONG', message.args[0]);
                 self.emit('ping', message.args[0]);
                 break;
-            case "PONG":
-                self.emit("pong", message.args[0]);
+            case 'PONG':
+                self.emit('pong', message.args[0]);
                 break;
-            case "NOTICE":
+            case 'NOTICE':
                 from = message.nick;
                 to = message.args[0];
                 if (!to) {
@@ -226,9 +226,9 @@ function Client(server, nick, opt) {
                 if (self.opt.debug && to == self.nick)
                     util.log('GOT NOTICE from ' + (from?'"'+from+'"':'the server') + ': "' + text + '"');
                 break;
-            case "MODE":
+            case 'MODE':
                 if (self.opt.debug)
-                    util.log("MODE: " + message.args[0] + " sets mode: " + message.args[1]);
+                    util.log('MODE: ' + message.args[0] + ' sets mode: ' + message.args[1]);
 
                 channel = self.chanData(message.args[0]);
                 if (!channel) break;
@@ -274,13 +274,13 @@ function Client(server, nick, opt) {
                     }
                 });
                 break;
-            case "NICK":
+            case 'NICK':
                 if (message.nick == self.nick)
                     // the user just changed their own nick
                     self.nick = message.args[0];
 
                 if (self.opt.debug)
-                    util.log("NICK: " + message.nick + " changes nick to " + message.args[0]);
+                    util.log('NICK: ' + message.nick + ' changes nick to ' + message.args[0]);
 
                 channels = [];
 
@@ -295,18 +295,18 @@ function Client(server, nick, opt) {
                 // old nick, new nick, channels
                 self.emit('nick', message.nick, message.args[0], channels, message);
                 break;
-            case "rpl_motdstart":
-                self.motd = message.args[1] + "\n";
+            case 'rpl_motdstart':
+                self.motd = message.args[1] + '\n';
                 break;
-            case "rpl_motd":
-                self.motd += message.args[1] + "\n";
+            case 'rpl_motd':
+                self.motd += message.args[1] + '\n';
                 break;
-            case "rpl_endofmotd":
-            case "err_nomotd":
-                self.motd += message.args[1] + "\n";
+            case 'rpl_endofmotd':
+            case 'err_nomotd':
+                self.motd += message.args[1] + '\n';
                 self.emit('motd', self.motd);
                 break;
-            case "rpl_namreply":
+            case 'rpl_namreply':
                 channel = self.chanData(message.args[2]);
                 var users = message.args[3].trim().split(/ +/);
                 if (channel) {
@@ -323,7 +323,7 @@ function Client(server, nick, opt) {
                     });
                 }
                 break;
-            case "rpl_endofnames":
+            case 'rpl_endofnames':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
                     self.emit('names', message.args[1], channel.users);
@@ -331,46 +331,46 @@ function Client(server, nick, opt) {
                     self.send('MODE', message.args[1]);
                 }
                 break;
-            case "rpl_topic":
+            case 'rpl_topic':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
                     channel.topic = message.args[2];
                 }
                 break;
-            case "rpl_away":
+            case 'rpl_away':
                 self._addWhoisData(message.args[1], 'away', message.args[2], true);
                 break;
-            case "rpl_whoisuser":
+            case 'rpl_whoisuser':
                 self._addWhoisData(message.args[1], 'user', message.args[2]);
                 self._addWhoisData(message.args[1], 'host', message.args[3]);
                 self._addWhoisData(message.args[1], 'realname', message.args[5]);
                 break;
-            case "rpl_whoisidle":
+            case 'rpl_whoisidle':
                 self._addWhoisData(message.args[1], 'idle', message.args[2]);
                 break;
-            case "rpl_whoischannels":
+            case 'rpl_whoischannels':
                // TODO - clean this up?
                 self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
                 break;
-            case "rpl_whoisserver":
+            case 'rpl_whoisserver':
                 self._addWhoisData(message.args[1], 'server', message.args[2]);
                 self._addWhoisData(message.args[1], 'serverinfo', message.args[3]);
                 break;
-            case "rpl_whoisoperator":
+            case 'rpl_whoisoperator':
                 self._addWhoisData(message.args[1], 'operator', message.args[2]);
                 break;
-            case "330": // rpl_whoisaccount?
+            case '330': // rpl_whoisaccount?
                 self._addWhoisData(message.args[1], 'account', message.args[2]);
                 self._addWhoisData(message.args[1], 'accountinfo', message.args[3]);
                 break;
-            case "rpl_endofwhois":
+            case 'rpl_endofwhois':
                 self.emit('whois', self._clearWhoisData(message.args[1]));
                 break;
-            case "rpl_liststart":
+            case 'rpl_liststart':
                 self.channellist = [];
                 self.emit('channellist_start');
                 break;
-            case "rpl_list":
+            case 'rpl_list':
                 channel = {
                     name: message.args[1],
                     users: message.args[2],
@@ -379,10 +379,10 @@ function Client(server, nick, opt) {
                 self.emit('channellist_item', channel);
                 self.channellist.push(channel);
                 break;
-            case "rpl_listend":
+            case 'rpl_listend':
                 self.emit('channellist', self.channellist);
                 break;
-            case "rpl_topicwhotime":
+            case 'rpl_topicwhotime':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
                     channel.topicBy = message.args[2];
@@ -390,7 +390,7 @@ function Client(server, nick, opt) {
                     self.emit('topic', message.args[1], channel.topic, channel.topicBy, message);
                 }
                 break;
-            case "TOPIC":
+            case 'TOPIC':
                 // channel, topic, nick
                 self.emit('topic', message.args[0], message.args[1], message.nick, message);
 
@@ -400,19 +400,19 @@ function Client(server, nick, opt) {
                     channel.topicBy = message.nick;
                 }
                 break;
-            case "rpl_channelmodeis":
+            case 'rpl_channelmodeis':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
                     channel.mode = message.args[2];
                 }
                 break;
-            case "rpl_creationtime":
+            case 'rpl_creationtime':
                 channel = self.chanData(message.args[1]);
                 if (channel) {
                     channel.created = message.args[2];
                 }
                 break;
-            case "JOIN":
+            case 'JOIN':
                 // channel, who
                 if (self.nick == message.nick) {
                     self.chanData(message.args[0], true);
@@ -429,7 +429,7 @@ function Client(server, nick, opt) {
                     self.emit('join' + message.args[0].toLowerCase(), message.nick, message);
                 }
                 break;
-            case "PART":
+            case 'PART':
                 // channel, who, reason
                 self.emit('part', message.args[0], message.nick, message.args[1], message);
                 self.emit('part' + message.args[0], message.nick, message.args[1], message);
@@ -447,7 +447,7 @@ function Client(server, nick, opt) {
                     }
                 }
                 break;
-            case "KICK":
+            case 'KICK':
                 // channel, who, by, reason
                 self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
                 self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
@@ -467,7 +467,7 @@ function Client(server, nick, opt) {
                     }
                 }
                 break;
-            case "KILL":
+            case 'KILL':
                 nick = message.args[0];
                 channels = [];
                 Object.keys(self.chans).forEach(function(channame) {
@@ -477,7 +477,7 @@ function Client(server, nick, opt) {
                 });
                 self.emit('kill', nick, message.args[1], channels, message);
                 break;
-            case "PRIVMSG":
+            case 'PRIVMSG':
                 from = message.nick;
                 to = message.args[0];
                 text = message.args[1] || '';
@@ -498,15 +498,15 @@ function Client(server, nick, opt) {
                 if (self.opt.debug && to == self.nick)
                     util.log('GOT MESSAGE from ' + from + ': ' + text);
                 break;
-            case "INVITE":
+            case 'INVITE':
                 from = message.nick;
                 to = message.args[0];
                 channel = message.args[1];
                 self.emit('invite', channel, from, message);
                 break;
-            case "QUIT":
+            case 'QUIT':
                 if (self.opt.debug)
-                    util.log("QUIT: " + message.prefix + " " + message.args.join(" "));
+                    util.log('QUIT: ' + message.prefix + ' ' + message.args.join(' '));
                 if (self.nick == message.nick) {
                     // TODO handle?
                     break;
@@ -527,32 +527,32 @@ function Client(server, nick, opt) {
                 break;
 
             // for sasl
-            case "CAP":
+            case 'CAP':
                 if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
                      message.args[2] === 'sasl ') // there's a space after sasl
-                    self.send("AUTHENTICATE", "PLAIN");
+                    self.send('AUTHENTICATE', 'PLAIN');
                 break;
-            case "AUTHENTICATE":
-                if (message.args[0] === '+') self.send( "AUTHENTICATE",
+            case 'AUTHENTICATE':
+                if (message.args[0] === '+') self.send( 'AUTHENTICATE',
                     new Buffer(
                         self.opt.nick + '\0' +
                         self.opt.userName + '\0' +
                         self.opt.password
                     ).toString('base64'));
                 break;
-            case "903":
-                self.send("CAP", "END");
+            case '903':
+                self.send('CAP', 'END');
                 break;
 
-            case "err_umodeunknownflag":
+            case 'err_umodeunknownflag':
                 if (self.opt.showErrors)
-                    util.log("\u001b[01;31mERROR: " + util.inspect(message) + "\u001b[0m");
+                    util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 break;
 
-            case "err_erroneusnickname":
+            case 'err_erroneusnickname':
                 if (self.opt.showErrors)
-                    util.log("\033[01;31mERROR: " + util.inspect(message) + "\033[0m");
+                    util.log('\033[01;31mERROR: ' + util.inspect(message) + '\033[0m');
                 self.emit('error', message);
                 break;
 
@@ -560,11 +560,11 @@ function Client(server, nick, opt) {
                 if (message.commandType == 'error') {
                     self.emit('error', message);
                     if (self.opt.showErrors)
-                        util.log("\u001b[01;31mERROR: " + util.inspect(message) + "\u001b[0m");
+                        util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 }
                 else {
                     if (self.opt.debug)
-                        util.log("\u001b[01;31mUnhandled message: " + util.inspect(message) + "\u001b[0m");
+                        util.log('\u001b[01;31mUnhandled message: ' + util.inspect(message) + '\u001b[0m');
                 break;
                 }
         }
@@ -638,14 +638,14 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
                      util.log('Connecting to server with expired certificate');
                 }
                 if (self.opt.password !==  null) {
-                    self.send("PASS", self.opt.password);
+                    self.send('PASS', self.opt.password);
                 }
                 if (self.opt.debug)
                     util.log('Sending irc NICK/USER');
-                self.send("NICK", self.opt.nick);
+                self.send('NICK', self.opt.nick);
                 self.nick = self.opt.nick;
-                self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
-                self.emit("connect");
+                self.send('USER', self.opt.userName, 8, '*', self.opt.realName);
+                self.emit('connect');
            } else {
               // authorization failed
              util.log(self.conn.authorizationError);
@@ -657,22 +657,22 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
-    self.conn.addListener("connect", function() {
+    self.conn.addListener('connect', function() {
         if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
-            self.send("CAP REQ", "sasl");
+            self.send('CAP REQ', 'sasl');
         } else if (self.opt.password !==  null) {
-            self.send( "PASS", self.opt.password );
+            self.send( 'PASS', self.opt.password );
         }
-        self.send("NICK", self.opt.nick);
+        self.send('NICK', self.opt.nick);
         self.nick = self.opt.nick;
-        self.send("USER", self.opt.userName, 8, "*", self.opt.realName);
-        self.emit("connect");
+        self.send('USER', self.opt.userName, 8, '*', self.opt.realName);
+        self.emit('connect');
     });
     var buffer = '';
-    self.conn.addListener("data", function(chunk) {
+    self.conn.addListener('data', function(chunk) {
         buffer += chunk;
-        var lines = buffer.split("\r\n");
+        var lines = buffer.split('\r\n');
         buffer = lines.pop();
         lines.forEach(function(line) {
             var message = parseMessage(line, self.opt.stripColors);
@@ -685,11 +685,11 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
             }
         });
     });
-    self.conn.addListener("end", function() {
+    self.conn.addListener('end', function() {
         if (self.opt.debug)
             util.log('Connection got "end" event');
     });
-    self.conn.addListener("close", function() {
+    self.conn.addListener('close', function() {
         if (self.opt.debug)
             util.log('Connection got "close" event');
         if (self.conn.requestedDisconnect)
@@ -711,8 +711,8 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
             self.connect( retryCount + 1 );
         }, self.opt.retryDelay );
     });
-    self.conn.addListener("error", function(exception) {
-        self.emit("netError", exception);
+    self.conn.addListener('error', function(exception) {
+        self.emit('netError', exception);
     });
 }; // }}}
 Client.prototype.disconnect = function( message, callback ) { // {{{
@@ -720,7 +720,7 @@ Client.prototype.disconnect = function( message, callback ) { // {{{
         callback = message;
         message = undefined;
     }
-    message = message || "node-irc says goodbye";
+    message = message || 'node-irc says goodbye';
     var self = this;
     if (self.conn.readyState == 'open') {
         var sendFunction;
@@ -730,7 +730,7 @@ Client.prototype.disconnect = function( message, callback ) { // {{{
         } else {
             sendFunction = self.send;
         }
-        sendFunction.call(self, "QUIT", message);
+        sendFunction.call(self, 'QUIT', message);
     }
     self.conn.requestedDisconnect = true;
     if (typeof(callback) === 'function') {
@@ -743,15 +743,15 @@ Client.prototype.send = function(command) { // {{{
 
     // Note that the command arg is included in the args array as the first element
 
-    if (args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === "") {
-        args[args.length-1] = ":" + args[args.length-1];
+    if (args[args.length-1].match(/\s/) || args[args.length-1].match(/^:/) || args[args.length-1] === '') {
+        args[args.length-1] = ':' + args[args.length-1];
     }
 
     if (this.opt.debug)
-        util.log('SEND: ' + args.join(" "));
+        util.log('SEND: ' + args.join(' '));
 
     if (!this.conn.requestedDisconnect) {
-        this.conn.write(args.join(" ") + "\r\n");
+        this.conn.write(args.join(' ') + '\r\n');
     }
 }; // }}}
 Client.prototype.activateFloodProtection = function(interval) { // {{{
@@ -833,7 +833,7 @@ Client.prototype.say = function(target, text) { // {{{
         text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;
         }).forEach(function(line) {
-            var r = new RegExp(".{1," + self.opt.messageSplit + "}", "g"),
+            var r = new RegExp('.{1,' + self.opt.messageSplit + '}', 'g'),
                 messagePart;
             while ((messagePart = r.exec(line)) !== null) {
                 self.send('PRIVMSG', target, messagePart[0]);
@@ -912,7 +912,7 @@ function parseMessage(line, stripColors) { // {{{
     var match;
 
     if (stripColors) {
-        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, "");
+        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
     }
 
     // Parse prefix

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -374,7 +374,7 @@ function Client(server, nick, opt) {
                 channel = {
                     name: message.args[1],
                     users: message.args[2],
-                    topic: message.args[3],
+                    topic: message.args[3]
                 };
                 self.emit('channellist_item', channel);
                 self.channellist.push(channel);
@@ -597,7 +597,7 @@ Client.prototype.chanData = function( name, create ) { // {{{
             key: key,
             serverName: name,
             users: {},
-            mode: '',
+            mode: ''
         };
     }
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -101,7 +101,7 @@ function Client(server, nick, opt) {
             text,
             to;
 
-        switch ( message.command ) {
+        switch (message.command) {
             case 'rpl_welcome':
                 // Set nick to whatever the server decided it really is
                 // (normally this is because you chose something too long and
@@ -162,7 +162,7 @@ function Client(server, nick, opt) {
                                 if (match) {
                                     match[1] = match[1].split('');
                                     match[2] = match[2].split('');
-                                    while ( match[1].length ) {
+                                    while (match[1].length) {
                                         self.modeForPrefix[match[2][0]] = match[1][0];
                                         self.supported.channel.modes.b += match[1][0];
                                         self.prefixForMode[match[1].shift()] = match[2].shift();
@@ -534,7 +534,7 @@ function Client(server, nick, opt) {
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':
-                if (message.args[0] === '+') self.send( 'AUTHENTICATE',
+                if (message.args[0] === '+') self.send('AUTHENTICATE',
                     new Buffer(
                         self.opt.nick + '\0' +
                         self.opt.userName + '\0' +
@@ -590,7 +590,7 @@ Client.prototype.prefixForMode = {};
 Client.prototype.modeForPrefix = {};
 Client.prototype.chans = {};
 Client.prototype._whoisData = {};
-Client.prototype.chanData = function( name, create ) { // {{{
+Client.prototype.chanData = function(name, create) { // {{{
     var key = name.toLowerCase();
     if (create) {
         this.chans[key] = this.chans[key] || {
@@ -603,7 +603,7 @@ Client.prototype.chanData = function( name, create ) { // {{{
 
     return this.chans[key];
 }; // }}}
-Client.prototype.connect = function( retryCount, callback ) { // {{{
+Client.prototype.connect = function(retryCount, callback) { // {{{
     if (typeof(retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
@@ -662,7 +662,7 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
         } else if (self.opt.password !==  null) {
-            self.send( 'PASS', self.opt.password );
+            self.send('PASS', self.opt.password);
         }
         self.send('NICK', self.opt.nick);
         self.nick = self.opt.nick;
@@ -678,7 +678,7 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
             var message = parseMessage(line, self.opt.stripColors);
             try {
                 self.emit('raw', message);
-            } catch ( err ) {
+            } catch (err) {
                 if (!self.conn.requestedDisconnect) {
                     throw err;
                 }
@@ -707,15 +707,15 @@ Client.prototype.connect = function( retryCount, callback ) { // {{{
         if (self.opt.debug) {
             util.log('Waiting ' + self.opt.retryDelay + 'ms before retrying');
         }
-        setTimeout( function() {
-            self.connect( retryCount + 1 );
-        }, self.opt.retryDelay );
+        setTimeout(function() {
+            self.connect(retryCount + 1);
+        }, self.opt.retryDelay);
     });
     self.conn.addListener('error', function(exception) {
         self.emit('netError', exception);
     });
 }; // }}}
-Client.prototype.disconnect = function( message, callback ) { // {{{
+Client.prototype.disconnect = function(message, callback) { // {{{
     if (typeof(message) === 'function') {
         callback = message;
         message = undefined;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -93,7 +93,7 @@ function Client(server, nick, opt) {
       self.connect();
     }
 
-    self.addListener("raw", function (message) { // {{{
+    self.addListener("raw", function(message) { // {{{
         var channels = [],
             channel,
             nick,
@@ -310,7 +310,7 @@ function Client(server, nick, opt) {
                 channel = self.chanData(message.args[2]);
                 var users = message.args[3].trim().split(/ +/);
                 if (channel) {
-                    users.forEach(function (user) {
+                    users.forEach(function(user) {
                         var match = user.match(/^(.)(.*)$/);
                         if (match) {
                             if (match[1] in self.modeForPrefix) {
@@ -574,7 +574,7 @@ function Client(server, nick, opt) {
         if (self.opt.autoRejoin)
             self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
     });
-    self.addListener('motd', function (motd) {
+    self.addListener('motd', function(motd) {
         self.opt.channels.forEach(function(channel) {
             self.send.apply(self, ['JOIN'].concat(channel.split(' ')));
         });
@@ -603,7 +603,7 @@ Client.prototype.chanData = function( name, create ) { // {{{
 
     return this.chans[key];
 }; // }}}
-Client.prototype.connect = function ( retryCount, callback ) { // {{{
+Client.prototype.connect = function( retryCount, callback ) { // {{{
     if (typeof(retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
@@ -657,7 +657,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(0);
     self.conn.setEncoding('utf8');
-    self.conn.addListener("connect", function () {
+    self.conn.addListener("connect", function() {
         if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send("CAP REQ", "sasl");
@@ -670,11 +670,11 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         self.emit("connect");
     });
     var buffer = '';
-    self.conn.addListener("data", function (chunk) {
+    self.conn.addListener("data", function(chunk) {
         buffer += chunk;
         var lines = buffer.split("\r\n");
         buffer = lines.pop();
-        lines.forEach(function (line) {
+        lines.forEach(function(line) {
             var message = parseMessage(line, self.opt.stripColors);
             try {
                 self.emit('raw', message);
@@ -715,7 +715,7 @@ Client.prototype.connect = function ( retryCount, callback ) { // {{{
         self.emit("netError", exception);
     });
 }; // }}}
-Client.prototype.disconnect = function ( message, callback ) { // {{{
+Client.prototype.disconnect = function( message, callback ) { // {{{
     if (typeof(message) === 'function') {
         callback = message;
         message = undefined;
@@ -768,11 +768,11 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
         cmdQueue.push(arguments);
     };
 
-    this._sendImmediate = function () {
+    this._sendImmediate = function() {
         origSend.apply(self, arguments);
     };
 
-    this._clearCmdQueue = function () {
+    this._clearCmdQueue = function() {
         cmdQueue = [];
     };
 
@@ -792,7 +792,7 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
 
 Client.prototype.join = function(channel, callback) { // {{{
     var channelName =  channel.split(' ')[0];
-    this.once('join' + channelName, function () {
+    this.once('join' + channelName, function() {
         // if join is successful, add this channel to opts.channels
         // so that it will be re-joined upon reconnect (as channels
         // specified in options are)

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -792,8 +792,6 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
     // Slowly unpack the queue without flooding.
     setInterval(dequeue, safeInterval);
     dequeue();
-
-
 }; // }}}
 
 Client.prototype.join = function(channel, callback) { // {{{

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -90,7 +90,7 @@ function Client(server, nick, opt) {
     // TODO - fail if nick or server missing
     // TODO - fail if username has a space in it
     if (self.opt.autoConnect === true) {
-      self.connect();
+        self.connect();
     }
 
     self.addListener('raw', function(message) { // {{{
@@ -565,7 +565,7 @@ function Client(server, nick, opt) {
                 else {
                     if (self.opt.debug)
                         util.log('\u001b[01;31mUnhandled message: ' + util.inspect(message) + '\u001b[0m');
-                break;
+                    break;
                 }
         }
     }); // }}}
@@ -610,7 +610,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
     }
     retryCount = retryCount || 0;
     if (typeof(callback) === 'function') {
-      this.once('registered', callback);
+        this.once('registered', callback);
     }
     var self = this;
     self.chans = {};
@@ -622,20 +622,20 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
         }
 
         self.conn = tls.connect(self.opt.port, self.opt.server, creds, function() {
-           // callback called only after successful socket connection
-           self.conn.connected = true;
-           if (self.conn.authorized ||
+            // callback called only after successful socket connection
+            self.conn.connected = true;
+            if (self.conn.authorized ||
                 (self.opt.selfSigned &&
-                   (self.conn.authorizationError   === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
-                      self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
-                      self.conn.authorizationError === 'SELF_SIGNED_CERT_IN_CHAIN')) ||
+                    (self.conn.authorizationError   === 'DEPTH_ZERO_SELF_SIGNED_CERT' ||
+                     self.conn.authorizationError === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' ||
+                     self.conn.authorizationError === 'SELF_SIGNED_CERT_IN_CHAIN')) ||
                 (self.opt.certExpired &&
-                   self.conn.authorizationError === 'CERT_HAS_EXPIRED')) {
-              // authorization successful
-              self.conn.setEncoding('utf-8');
+                 self.conn.authorizationError === 'CERT_HAS_EXPIRED')) {
+                // authorization successful
+                self.conn.setEncoding('utf-8');
                 if (self.opt.certExpired &&
-                   self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
-                     util.log('Connecting to server with expired certificate');
+                    self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
+                    util.log('Connecting to server with expired certificate');
                 }
                 if (self.opt.password !==  null) {
                     self.send('PASS', self.opt.password);
@@ -646,10 +646,10 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                 self.nick = self.opt.nick;
                 self.send('USER', self.opt.userName, 8, '*', self.opt.realName);
                 self.emit('connect');
-           } else {
-              // authorization failed
-             util.log(self.conn.authorizationError);
-           }
+            } else {
+                // authorization failed
+                util.log(self.conn.authorizationError);
+            }
         });
     }else {
         self.conn = net.createConnection(self.opt.port, self.opt.server);
@@ -734,7 +734,7 @@ Client.prototype.disconnect = function(message, callback) { // {{{
     }
     self.conn.requestedDisconnect = true;
     if (typeof(callback) === 'function') {
-      self.conn.once('end', callback);
+        self.conn.once('end', callback);
     }
     self.conn.end();
 }; // }}}
@@ -822,9 +822,9 @@ Client.prototype.part = function(channel, message, callback) { // {{{
     }
 
     if (message) {
-	    this.send('PART', channel, message);
+        this.send('PART', channel, message);
     } else {
-    	this.send('PART', channel);
+        this.send('PART', channel);
     }
 }; // }}}
 Client.prototype.say = function(target, text) { // {{{

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -119,7 +119,7 @@ function Client(server, nick, opt) {
                     if (match) {
                         var param = match[1];
                         var value = match[2];
-                        switch(param) {
+                        switch (param) {
                             case 'CHANLIMIT':
                                 value.split(',').forEach(function(val) {
                                     val = val.split(':');
@@ -197,7 +197,7 @@ function Client(server, nick, opt) {
                 // Random welcome crap, ignoring
                 break;
             case 'err_nicknameinuse':
-                if (typeof(self.opt.nickMod) == 'undefined')
+                if (typeof (self.opt.nickMod) == 'undefined')
                     self.opt.nickMod = 0;
                 self.opt.nickMod++;
                 self.send('NICK', self.opt.nick + self.opt.nickMod);
@@ -224,7 +224,7 @@ function Client(server, nick, opt) {
                 self.emit('notice', from, to, text, message);
 
                 if (self.opt.debug && to == self.nick)
-                    util.log('GOT NOTICE from ' + (from?'"'+from+'"':'the server') + ': "' + text + '"');
+                    util.log('GOT NOTICE from ' + (from ? '"' + from + '"' : 'the server') + ': "' + text + '"');
                 break;
             case 'MODE':
                 if (self.opt.debug)
@@ -604,12 +604,12 @@ Client.prototype.chanData = function(name, create) { // {{{
     return this.chans[key];
 }; // }}}
 Client.prototype.connect = function(retryCount, callback) { // {{{
-    if (typeof(retryCount) === 'function') {
+    if (typeof (retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
     }
     retryCount = retryCount || 0;
-    if (typeof(callback) === 'function') {
+    if (typeof (callback) === 'function') {
         this.once('registered', callback);
     }
     var self = this;
@@ -716,7 +716,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
     });
 }; // }}}
 Client.prototype.disconnect = function(message, callback) { // {{{
-    if (typeof(message) === 'function') {
+    if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
     }
@@ -733,7 +733,7 @@ Client.prototype.disconnect = function(message, callback) { // {{{
         sendFunction.call(self, 'QUIT', message);
     }
     self.conn.requestedDisconnect = true;
-    if (typeof(callback) === 'function') {
+    if (typeof (callback) === 'function') {
         self.conn.once('end', callback);
     }
     self.conn.end();
@@ -800,18 +800,18 @@ Client.prototype.join = function(channel, callback) { // {{{
             this.opt.channels.push(channel);
         }
 
-        if (typeof(callback) == 'function') {
+        if (typeof (callback) == 'function') {
             return callback.apply(this, arguments);
         }
     });
     this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
 }; // }}}
 Client.prototype.part = function(channel, message, callback) { // {{{
-    if (typeof(message) === 'function') {
+    if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
     }
-    if (typeof(callback) == 'function') {
+    if (typeof (callback) == 'function') {
         this.once('part' + channel, callback);
     }
 
@@ -959,7 +959,7 @@ function parseMessage(line, stripColors) { // {{{
     if (middle.length)
         message.args = middle.split(/ +/);
 
-    if (typeof(trailing) != 'undefined' && trailing.length)
+    if (typeof (trailing) != 'undefined' && trailing.length)
         message.args.push(trailing);
 
     return message;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -236,8 +236,14 @@ function Client(server, nick, opt) {
                 var adding = true;
                 var modeArgs = message.args.slice(2);
                 modeList.forEach(function(mode) {
-                    if (mode == '+') { adding = true; return; }
-                    if (mode == '-') { adding = false; return; }
+                    if (mode == '+') {
+                        adding = true;
+                        return;
+                    }
+                    if (mode == '-') {
+                        adding = false;
+                        return;
+                    }
                     if (mode in self.prefixForMode) {
                         // channel user modes
                         var user = modeArgs.shift();

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.3.7",
   "author": "Martyn Smith <martyn@dollyfish.net.nz>",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --reporter list"
+    "test": "./node_modules/mocha/bin/mocha --reporter list",
+    "lint": "./node_modules/jshint/bin/jshint */*.js"
   },
   "contributors": [
-      "Fionn Kelleher <me@fionn.co>",
-      "xAndy <xandy@hackerspace-bamberg.de>"
+    "Fionn Kelleher <me@fionn.co>",
+    "xAndy <xandy@hackerspace-bamberg.de>"
   ],
   "repository": {
     "type": "git",
@@ -32,8 +33,19 @@
     "ansi-color": "0.2.1"
   },
   "devDependencies": {
+    "jshint": "^2.5.11",
     "mocha": "^1.20.0",
     "should": "1.2.2",
     "underscore": "^1.6.0"
+  },
+  "jshintConfig": {
+    "node": true,
+    "smarttabs": true,
+    "undef": true,
+    "unused": "vars",
+    "newcap": true,
+    "maxlen": 120,
+    "indent": 2,
+    "mocha": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Martyn Smith <martyn@dollyfish.net.nz>",
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --reporter list",
-    "lint": "./node_modules/jshint/bin/jshint */*.js"
+    "lint": "./node_modules/jscs/bin/jscs --preset=airbnb */*.js"
   },
   "contributors": [
     "Fionn Kelleher <me@fionn.co>",
@@ -33,19 +33,9 @@
     "ansi-color": "0.2.1"
   },
   "devDependencies": {
-    "jshint": "^2.5.11",
+    "jscs": "^1.9.0",
     "mocha": "^1.20.0",
     "should": "1.2.2",
     "underscore": "^1.6.0"
-  },
-  "jshintConfig": {
-    "node": true,
-    "smarttabs": true,
-    "undef": true,
-    "unused": "vars",
-    "newcap": true,
-    "maxlen": 120,
-    "indent": 2,
-    "mocha": true
   }
 }

--- a/test/parse-line.js
+++ b/test/parse-line.js
@@ -12,7 +12,7 @@ describe('irc.parseMessage', function() {
             command: 'rpl_motd',
             rawCommand: '372',
             commandType: 'reply',
-            args: [ 'nodebot', 'The message of the day was last changed: 2012-6-16 23:57' ]
+            args: ['nodebot', 'The message of the day was last changed: 2012-6-16 23:57']
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test :Hello nodebot!': {
             prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
@@ -22,7 +22,7 @@ describe('irc.parseMessage', function() {
             command: 'PRIVMSG',
             rawCommand: 'PRIVMSG',
             commandType: 'normal',
-            args: [ '#test', 'Hello nodebot!' ]
+            args: ['#test', 'Hello nodebot!']
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::-)': {
             prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
@@ -32,7 +32,7 @@ describe('irc.parseMessage', function() {
             command: 'PRIVMSG',
             rawCommand: 'PRIVMSG',
             commandType: 'normal',
-            args: [ '#test', ':-)' ]
+            args: ['#test', ':-)']
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::': {
             prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
@@ -42,7 +42,7 @@ describe('irc.parseMessage', function() {
             command: 'PRIVMSG',
             rawCommand: 'PRIVMSG',
             commandType: 'normal',
-            args: [ '#test', ':' ]
+            args: ['#test', ':']
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::^:^:': {
             prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
@@ -52,7 +52,7 @@ describe('irc.parseMessage', function() {
             command: 'PRIVMSG',
             rawCommand: 'PRIVMSG',
             commandType: 'normal',
-            args: [ '#test', ':^:^:' ]
+            args: ['#test', ':^:^:']
         },
         ':some.irc.net 324 webuser #channel +Cnj 5:10': {
             prefix: 'some.irc.net',
@@ -60,7 +60,7 @@ describe('irc.parseMessage', function() {
             command: 'rpl_channelmodeis',
             rawCommand: '324',
             commandType: 'reply',
-            args: [ 'webuser', '#channel', '+Cnj', '5:10' ]
+            args: ['webuser', '#channel', '+Cnj', '5:10']
         },
         ':nick!user@host QUIT :Ping timeout: 252 seconds': {
             prefix: 'nick!user@host',
@@ -70,7 +70,7 @@ describe('irc.parseMessage', function() {
             command: 'QUIT',
             rawCommand: 'QUIT',
             commandType: 'normal',
-            args: [ 'Ping timeout: 252 seconds' ]
+            args: ['Ping timeout: 252 seconds']
         },
         ':nick!user@host PRIVMSG #channel :so : colons: :are :: not a problem ::::': {
             prefix: 'nick!user@host',
@@ -80,7 +80,7 @@ describe('irc.parseMessage', function() {
             command: 'PRIVMSG',
             rawCommand: 'PRIVMSG',
             commandType: 'normal',
-            args: [ '#channel', 'so : colons: :are :: not a problem ::::' ]
+            args: ['#channel', 'so : colons: :are :: not a problem ::::']
         },
         ':pratchett.freenode.net 324 nodebot #ubuntu +CLcntjf 5:10 #ubuntu-unregged': {
             prefix: 'pratchett.freenode.net',
@@ -88,7 +88,7 @@ describe('irc.parseMessage', function() {
             command: 'rpl_channelmodeis',
             rawCommand: '324',
             commandType: 'reply',
-            args: [ 'nodebot', '#ubuntu', '+CLcntjf', '5:10', '#ubuntu-unregged' ]
+            args: ['nodebot', '#ubuntu', '+CLcntjf', '5:10', '#ubuntu-unregged']
         }
     };
 

--- a/test/parse-line.js
+++ b/test/parse-line.js
@@ -4,85 +4,85 @@ var irc  = require('../lib/irc.js');
 var should = require('should');
 var _ = require('underscore');
 
-describe("irc.parseMessage", function() {
+describe('irc.parseMessage', function() {
     var checks = {
         ':irc.dollyfish.net.nz 372 nodebot :The message of the day was last changed: 2012-6-16 23:57': {
-            prefix: "irc.dollyfish.net.nz",
-            server: "irc.dollyfish.net.nz",
-            command: "rpl_motd",
-            rawCommand: "372",
-            commandType: "reply",
-            args: [ "nodebot", "The message of the day was last changed: 2012-6-16 23:57" ]
+            prefix: 'irc.dollyfish.net.nz',
+            server: 'irc.dollyfish.net.nz',
+            command: 'rpl_motd',
+            rawCommand: '372',
+            commandType: 'reply',
+            args: [ 'nodebot', 'The message of the day was last changed: 2012-6-16 23:57' ]
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test :Hello nodebot!': {
-            prefix: "Ned!~martyn@irc.dollyfish.net.nz",
-            nick: "Ned",
-            user: "~martyn",
-            host: "irc.dollyfish.net.nz",
-            command: "PRIVMSG",
-            rawCommand: "PRIVMSG",
-            commandType: "normal",
-            args: [ "#test", "Hello nodebot!" ]
+            prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
+            nick: 'Ned',
+            user: '~martyn',
+            host: 'irc.dollyfish.net.nz',
+            command: 'PRIVMSG',
+            rawCommand: 'PRIVMSG',
+            commandType: 'normal',
+            args: [ '#test', 'Hello nodebot!' ]
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::-)': {
-            prefix: "Ned!~martyn@irc.dollyfish.net.nz",
-            nick: "Ned",
-            user: "~martyn",
-            host: "irc.dollyfish.net.nz",
-            command: "PRIVMSG",
-            rawCommand: "PRIVMSG",
-            commandType: "normal",
-            args: [ "#test", ":-)" ]
+            prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
+            nick: 'Ned',
+            user: '~martyn',
+            host: 'irc.dollyfish.net.nz',
+            command: 'PRIVMSG',
+            rawCommand: 'PRIVMSG',
+            commandType: 'normal',
+            args: [ '#test', ':-)' ]
         },
         ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::': {
-            prefix: "Ned!~martyn@irc.dollyfish.net.nz",
-            nick: "Ned",
-            user: "~martyn",
-            host: "irc.dollyfish.net.nz",
-            command: "PRIVMSG",
-            rawCommand: "PRIVMSG",
-            commandType: "normal",
-            args: [ "#test", ":" ]
+            prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
+            nick: 'Ned',
+            user: '~martyn',
+            host: 'irc.dollyfish.net.nz',
+            command: 'PRIVMSG',
+            rawCommand: 'PRIVMSG',
+            commandType: 'normal',
+            args: [ '#test', ':' ]
         },
-        ":Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::^:^:": {
-            prefix: "Ned!~martyn@irc.dollyfish.net.nz",
-            nick: "Ned",
-            user: "~martyn",
-            host: "irc.dollyfish.net.nz",
-            command: "PRIVMSG",
-            rawCommand: "PRIVMSG",
-            commandType: "normal",
-            args: [ "#test", ":^:^:" ]
+        ':Ned!~martyn@irc.dollyfish.net.nz PRIVMSG #test ::^:^:': {
+            prefix: 'Ned!~martyn@irc.dollyfish.net.nz',
+            nick: 'Ned',
+            user: '~martyn',
+            host: 'irc.dollyfish.net.nz',
+            command: 'PRIVMSG',
+            rawCommand: 'PRIVMSG',
+            commandType: 'normal',
+            args: [ '#test', ':^:^:' ]
         },
-        ":some.irc.net 324 webuser #channel +Cnj 5:10": {
-            prefix: "some.irc.net",
-            server: "some.irc.net",
-            command: "rpl_channelmodeis",
-            rawCommand: "324",
-            commandType: "reply",
-            args: [ "webuser", "#channel", "+Cnj", "5:10" ]
+        ':some.irc.net 324 webuser #channel +Cnj 5:10': {
+            prefix: 'some.irc.net',
+            server: 'some.irc.net',
+            command: 'rpl_channelmodeis',
+            rawCommand: '324',
+            commandType: 'reply',
+            args: [ 'webuser', '#channel', '+Cnj', '5:10' ]
         },
-        ":nick!user@host QUIT :Ping timeout: 252 seconds": {
-            prefix: "nick!user@host",
-            nick: "nick",
-            user: "user",
-            host: "host",
-            command: "QUIT",
-            rawCommand: "QUIT",
-            commandType: "normal",
-            args: [ "Ping timeout: 252 seconds" ]
+        ':nick!user@host QUIT :Ping timeout: 252 seconds': {
+            prefix: 'nick!user@host',
+            nick: 'nick',
+            user: 'user',
+            host: 'host',
+            command: 'QUIT',
+            rawCommand: 'QUIT',
+            commandType: 'normal',
+            args: [ 'Ping timeout: 252 seconds' ]
         },
-        ":nick!user@host PRIVMSG #channel :so : colons: :are :: not a problem ::::": {
-            prefix: "nick!user@host",
-            nick: "nick",
-            user: "user",
-            host: "host",
-            command: "PRIVMSG",
-            rawCommand: "PRIVMSG",
-            commandType: "normal",
-            args: [ "#channel", "so : colons: :are :: not a problem ::::" ]
+        ':nick!user@host PRIVMSG #channel :so : colons: :are :: not a problem ::::': {
+            prefix: 'nick!user@host',
+            nick: 'nick',
+            user: 'user',
+            host: 'host',
+            command: 'PRIVMSG',
+            rawCommand: 'PRIVMSG',
+            commandType: 'normal',
+            args: [ '#channel', 'so : colons: :are :: not a problem ::::' ]
         },
-        ":pratchett.freenode.net 324 nodebot #ubuntu +CLcntjf 5:10 #ubuntu-unregged": {
+        ':pratchett.freenode.net 324 nodebot #ubuntu +CLcntjf 5:10 #ubuntu-unregged': {
             prefix: 'pratchett.freenode.net',
             server: 'pratchett.freenode.net',
             command: 'rpl_channelmodeis',

--- a/test/parse-line.js
+++ b/test/parse-line.js
@@ -1,3 +1,5 @@
+// jshint unused:false
+
 var irc  = require('../lib/irc.js');
 var should = require('should');
 var _ = require('underscore');


### PR DESCRIPTION
# What
Start using [travis-ci](https://travis-ci.org) for CI. Use [jscs](https://github.com/jscs-dev/node-jscs) for lint, and run `npm test` for tests.

# Why
CI helps speed up development with automatic validation of incoming Pull Requests. Using a linter makes a consistent code style for readability and catching simple and common bugs.

# Lint details
Using `jscs` this implements *mostly* the [airbnb javascript style](https://github.com/airbnb/javascript). The differences are:
* 4 spaces for indentation instead of 2
* camelCase isn't required for `Object` properties
* `self` is the accepted keyword for storing context across closures instead of `_this`
* Don't require a single `var` statement per scope