### PR TITLE
fix(style): Remove folding hints from codes and irc.

### DIFF
--- a/lib/codes.js
+++ b/lib/codes.js
@@ -1,4 +1,4 @@
-module.exports = { // {{{
+module.exports = {
    '001': {
       name: 'rpl_welcome',
       type: 'reply'
@@ -511,4 +511,4 @@ module.exports = { // {{{
       name: 'err_usersdontmatch',
       type: 'error'
    }
-}; // }}}
+};

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -93,7 +93,7 @@ function Client(server, nick, opt) {
         self.connect();
     }
 
-    self.addListener('raw', function(message) { // {{{
+    self.addListener('raw', function(message) {
         var channels = [],
             channel,
             nick,
@@ -585,7 +585,7 @@ function Client(server, nick, opt) {
                     break;
                 }
         }
-    }); // }}}
+    });
 
     self.addListener('kick', function(channel, who, by, reason) {
         if (self.opt.autoRejoin)
@@ -607,7 +607,7 @@ Client.prototype.prefixForMode = {};
 Client.prototype.modeForPrefix = {};
 Client.prototype.chans = {};
 Client.prototype._whoisData = {};
-Client.prototype.chanData = function(name, create) { // {{{
+Client.prototype.chanData = function(name, create) {
     var key = name.toLowerCase();
     if (create) {
         this.chans[key] = this.chans[key] || {
@@ -619,8 +619,8 @@ Client.prototype.chanData = function(name, create) { // {{{
     }
 
     return this.chans[key];
-}; // }}}
-Client.prototype.connect = function(retryCount, callback) { // {{{
+};
+Client.prototype.connect = function(retryCount, callback) {
     if (typeof (retryCount) === 'function') {
         callback = retryCount;
         retryCount = undefined;
@@ -731,8 +731,8 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
     self.conn.addListener('error', function(exception) {
         self.emit('netError', exception);
     });
-}; // }}}
-Client.prototype.disconnect = function(message, callback) { // {{{
+};
+Client.prototype.disconnect = function(message, callback) {
     if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
@@ -754,8 +754,8 @@ Client.prototype.disconnect = function(message, callback) { // {{{
         self.conn.once('end', callback);
     }
     self.conn.end();
-}; // }}}
-Client.prototype.send = function(command) { // {{{
+};
+Client.prototype.send = function(command) {
     var args = Array.prototype.slice.call(arguments);
 
     // Note that the command arg is included in the args array as the first element
@@ -770,8 +770,8 @@ Client.prototype.send = function(command) { // {{{
     if (!this.conn.requestedDisconnect) {
         this.conn.write(args.join(' ') + '\r\n');
     }
-}; // }}}
-Client.prototype.activateFloodProtection = function(interval) { // {{{
+};
+Client.prototype.activateFloodProtection = function(interval) {
 
     var cmdQueue = [],
         safeInterval = interval || this.opt.floodProtectionDelay,
@@ -803,9 +803,9 @@ Client.prototype.activateFloodProtection = function(interval) { // {{{
     // Slowly unpack the queue without flooding.
     setInterval(dequeue, safeInterval);
     dequeue();
-}; // }}}
+};
 
-Client.prototype.join = function(channel, callback) { // {{{
+Client.prototype.join = function(channel, callback) {
     var channelName =  channel.split(' ')[0];
     this.once('join' + channelName, function() {
         // if join is successful, add this channel to opts.channels
@@ -820,8 +820,8 @@ Client.prototype.join = function(channel, callback) { // {{{
         }
     });
     this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
-}; // }}}
-Client.prototype.part = function(channel, message, callback) { // {{{
+};
+Client.prototype.part = function(channel, message, callback) {
     if (typeof (message) === 'function') {
         callback = message;
         message = undefined;
@@ -841,8 +841,8 @@ Client.prototype.part = function(channel, message, callback) { // {{{
     } else {
         this.send('PART', channel);
     }
-}; // }}}
-Client.prototype.action = function(channel, text) { // {{{
+};
+Client.prototype.action = function(channel, text) {
     var self = this;
     if (typeof text !== 'undefined') {
         text.toString().split(/\r?\n/).filter(function(line) {
@@ -851,8 +851,8 @@ Client.prototype.action = function(channel, text) { // {{{
             self.say(channel, '\u0001ACTION ' + line + '\u0001');
         });
     }
-}; // }}}
-Client.prototype._splitLongLines = function(words, maxLength, destination) { // {{{
+};
+Client.prototype._splitLongLines = function(words, maxLength, destination) {
     if (words.length < maxLength) {
         destination.push(words);
         return destination;
@@ -878,14 +878,14 @@ Client.prototype._splitLongLines = function(words, maxLength, destination) { // 
     var part = words.substring(0, cutPos);
     destination.push(part);
     return this._splitLongLines(words.substring(cutPos + 1, words.length), maxLength, destination);
-}; // }}}
-Client.prototype.say = function(target, text) { // {{{
+};
+Client.prototype.say = function(target, text) {
     this._speak('PRIVMSG', target, text);
-}; // }}}
-Client.prototype.notice = function(target, text) { // {{{
+};
+Client.prototype.notice = function(target, text) {
     this._speak('NOTICE', target, text);
-}; // }}}
-Client.prototype._speak = function(kind, target, text) { // {{{
+};
+Client.prototype._speak = function(kind, target, text) {
     var self = this;
     var maxLength = this.maxLineLength - target.length;
     if (typeof text !== 'undefined') {
@@ -901,8 +901,8 @@ Client.prototype._speak = function(kind, target, text) { // {{{
             });
         });
     }
-}; // }}}
-Client.prototype.whois = function(nick, callback) { // {{{
+};
+Client.prototype.whois = function(nick, callback) {
     if (typeof callback === 'function') {
         var callbackWrapper = function(info) {
             if (info.nick == nick) {
@@ -913,24 +913,24 @@ Client.prototype.whois = function(nick, callback) { // {{{
         this.addListener('whois', callbackWrapper);
     }
     this.send('WHOIS', nick);
-}; // }}}
-Client.prototype.list = function() { // {{{
+};
+Client.prototype.list = function() {
     var args = Array.prototype.slice.call(arguments, 0);
     args.unshift('LIST');
     this.send.apply(this, args);
-}; // }}}
-Client.prototype._addWhoisData = function(nick, key, value, onlyIfExists) { // {{{
+};
+Client.prototype._addWhoisData = function(nick, key, value, onlyIfExists) {
     if (onlyIfExists && !this._whoisData[nick]) return;
     this._whoisData[nick] = this._whoisData[nick] || {nick: nick};
     this._whoisData[nick][key] = value;
-}; // }}}
-Client.prototype._clearWhoisData = function(nick) { // {{{
+};
+Client.prototype._clearWhoisData = function(nick) {
     // Ensure that at least the nick exists before trying to return
     this._addWhoisData(nick, 'nick', nick);
     var data = this._whoisData[nick];
     delete this._whoisData[nick];
     return data;
-}; // }}}
+};
 Client.prototype._handleCTCP = function(from, to, text, type, message) {
     text = text.slice(1);
     text = text.slice(0, text.indexOf('\u0001'));
@@ -960,7 +960,7 @@ Client.prototype._updateMaxLineLength = function() {
  * takes a raw "line" from the IRC server and turns it into an object with
  * useful keys
  */
-function parseMessage(line, stripColors) { // {{{
+function parseMessage(line, stripColors) {
     var message = {};
     var match;
 
@@ -1016,6 +1016,6 @@ function parseMessage(line, stripColors) { // {{{
         message.args.push(trailing);
 
     return message;
-} // }}}
+}
 
 exports.parseMessage = parseMessage;


### PR DESCRIPTION
This just removes the // {{{ and // }}} littered throughout the code.

Replaces #272 as this is rebased on `master` instead of `0.3.x`