### PR TITLE
WEBIRC support

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -41,6 +41,7 @@ function Client(server, nick, opt) {
         autoRejoin: true,
         autoConnect: true,
         channels: [],
+        webirc: {},
         retryCount: null,
         retryDelay: 2000,
         secure: false,
@@ -654,6 +655,9 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                     self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
                     util.log('Connecting to server with expired certificate');
                 }
+                if (typeof self.opt.webirc.ip !== 'undefined') {
+                    self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+                }
                 if (self.opt.password !==  null) {
                     self.send('PASS', self.opt.password);
                 }
@@ -678,7 +682,10 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
         if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
-        } else if (self.opt.password !==  null) {
+        } 
+        if (typeof self.opt.webirc.ip !== 'undefined') {
+            self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+        }else if (self.opt.password !==  null) {
             self.send('PASS', self.opt.password);
         }
         self.send('NICK', self.opt.nick);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -682,7 +682,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
         if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
-        } 
+        }
         if (typeof self.opt.webirc.ip) {
             self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
         }else if (self.opt.password) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -656,7 +656,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                     util.log('Connecting to server with expired certificate');
                 }
                 if (typeof self.opt.webirc.ip) {
-                    self.send('WEBIRC',self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+                    self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
                 }
                 if (self.opt.password) {
                     self.send('PASS', self.opt.password);
@@ -684,7 +684,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
             self.send('CAP REQ', 'sasl');
         } 
         if (typeof self.opt.webirc.ip) {
-            self.send('WEBIRC',self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+            self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
         }else if (self.opt.password) {
             self.send('PASS', self.opt.password);
         }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -655,7 +655,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                     self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
                     util.log('Connecting to server with expired certificate');
                 }
-                if (typeof self.opt.webirc.ip !== 'undefined') {
+                if (typeof self.opt.webirc.ip !== null) {
                     self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
                 }
                 if (self.opt.password !==  null) {
@@ -683,7 +683,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
         } 
-        if (typeof self.opt.webirc.ip !== 'undefined') {
+        if (typeof self.opt.webirc.ip !== null) {
             self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
         }else if (self.opt.password !==  null) {
             self.send('PASS', self.opt.password);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -655,10 +655,10 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                     self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
                     util.log('Connecting to server with expired certificate');
                 }
-                if (typeof self.opt.webirc.ip !== null) {
+                if (typeof self.opt.webirc.ip) {
                     self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
                 }
-                if (self.opt.password !==  null) {
+                if (self.opt.password) {
                     self.send('PASS', self.opt.password);
                 }
                 if (self.opt.debug)
@@ -683,9 +683,9 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
         } 
-        if (typeof self.opt.webirc.ip !== null) {
+        if (typeof self.opt.webirc.ip) {
             self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
-        }else if (self.opt.password !==  null) {
+        }else if (self.opt.password) {
             self.send('PASS', self.opt.password);
         }
         self.send('NICK', self.opt.nick);

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -656,7 +656,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
                     util.log('Connecting to server with expired certificate');
                 }
                 if (typeof self.opt.webirc.ip) {
-                    self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+                    self.send('WEBIRC',self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
                 }
                 if (self.opt.password) {
                     self.send('PASS', self.opt.password);
@@ -684,7 +684,7 @@ Client.prototype.connect = function(retryCount, callback) { // {{{
             self.send('CAP REQ', 'sasl');
         } 
         if (typeof self.opt.webirc.ip) {
-            self.send("WEBIRC",self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
+            self.send('WEBIRC',self.opt.webirc.pass,self.opt.userName,self.opt.webirc.host,self.opt.webirc.ip);
         }else if (self.opt.password) {
             self.send('PASS', self.opt.password);
         }


### PR DESCRIPTION
Webirc is used for multiple users to connect from your node-irc server to irc to get the clients ip.
Get the users ip and hostname and send it like this:
webirc = {"pass":"WebIrcPassWord","host":"my.host.com", "ip":"123.123.12.12"};

http://wiki.mibbit.com/index.php/Enable_Mibbit_on_Your_IRC_Server
How to configure your server for Webirc can also be found in your irc server dokumentation.