### PR TITLE
Fix data split delimiter

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -28,6 +28,8 @@ exports.colors = colors;
 
 var replyFor = require('./codes');
 
+var lineDelimiter = new RegExp('\r\n|\r|\n')
+
 function Client(server, nick, opt) {
     var self = this;
     self.opt = {
@@ -736,7 +738,7 @@ Client.prototype.connect = function(retryCount, callback) {
             buffer = Buffer.concat([buffer, chunk]);
         }
 
-        var lines = self.convertEncoding(buffer).toString().split(/\r\n|\r|\n/);
+        var lines = self.convertEncoding(buffer).toString().split(lineDelimiter);
 
         if (lines.pop()) {
             // if buffer is not ended with \r\n, there's more chunks.

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -736,7 +736,7 @@ Client.prototype.connect = function(retryCount, callback) {
             buffer = Buffer.concat([buffer, chunk]);
         }
 
-        var lines = self.convertEncoding(buffer).toString().split('\r\n');
+        var lines = self.convertEncoding(buffer).toString().split(/\r\n|\r|\n/);
 
         if (lines.pop()) {
             // if buffer is not ended with \r\n, there's more chunks.


### PR DESCRIPTION
IRC Protocol use CR-LF, but legacy IRC server send other code.
http://tools.ietf.org/html/rfc1459.html#section-8

So, replace split string from \r\n with /\r\n|\r|\n/
