### PR TITLE
fix(irc.js): Use the proper EventEmitter class.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -21,6 +21,7 @@ exports.Client = Client;
 var net  = require('net');
 var tls  = require('tls');
 var util = require('util');
+var EventEmitter = require('events').EventEmitter;
 
 var colors = require('./colors');
 exports.colors = colors;
@@ -598,10 +599,10 @@ function Client(server, nick, opt) {
         });
     });
 
-    process.EventEmitter.call(this);
+    EventEmitter.call(this);
 }
 
-util.inherits(Client, process.EventEmitter);
+util.inherits(Client, EventEmitter);
 
 Client.prototype.conn = null;
 Client.prototype.prefixForMode = {};


### PR DESCRIPTION
This is a small change that should be a no-op. It isn't safe to rely one `process.EventEmitter` as this is an underlying implementation detail and is a remnant of an older and scarier time.