### PR TITLE
fix(webirc): Set sane defaults for WEBIRC options.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -55,7 +55,12 @@ function Client(server, nick, opt) {
         stripColors: false,
         channelPrefixes: '&#',
         messageSplit: 512,
-        encoding: false
+        encoding: false,
+        webirc: {
+          pass: '',
+          ip: '',
+          user: ''
+        }
     };
 
     // Features supported by the server
@@ -679,7 +684,7 @@ Client.prototype.connect = function(retryCount, callback) {
                     self.conn.authorizationError === 'CERT_HAS_EXPIRED') {
                     util.log('Connecting to server with expired certificate');
                 }
-                if (typeof self.opt.webirc.ip) {
+                if (self.opt.webirc.ip && self.opt.webirc.pass && self.opt.webirc.host) {
                     self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
                 }
                 if (self.opt.password) {
@@ -711,7 +716,7 @@ Client.prototype.connect = function(retryCount, callback) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');
         }
-        if (typeof self.opt.webirc.ip) {
+        if (self.opt.webirc.ip && self.opt.webirc.pass && self.opt.webirc.host) {
             self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
         }else if (self.opt.password) {
             self.send('PASS', self.opt.password);


### PR DESCRIPTION
Also don't send the WEBIRC message if all of the required options aren't defined.