### PR TITLE
_updateMaxLineLength() can be called before 001

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1022,7 +1022,8 @@ Client.prototype.convertEncoding = function(str) {
 Client.prototype._updateMaxLineLength = function() {
     // 497 = 510 - (":" + "!" + " PRIVMSG " + " :").length;
     // target is determined in _speak() and subtracted there
-    this.maxLineLength = 497 - this.nick.length - this.hostMask.length;
+    var hostLength = (typeof (this.hostMask) === 'undefined') ? 0 : this.hostMask.length;
+    this.maxLineLength = 497 - this.nick.length - hostLength;
 };
 /*
  * parseMessage(line, stripColors)


### PR DESCRIPTION
Fix _updateMaxLineLength() to not crash when this.hostMask is not set yet.