### PR TITLE
exports codes & parseMessage

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -27,6 +27,7 @@ var colors = require('./colors');
 exports.colors = colors;
 
 var replyFor = require('./codes');
+exports.codes = replyFor;
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
@@ -748,7 +749,7 @@ Client.prototype.connect = function(retryCount, callback) {
         }
 
         lines.forEach(function iterator(line) {
-            var message = parseMessage(line, self.opt.stripColors);
+            var message = exports.parseMessage(line, self.opt.stripColors);
 
             try {
                 self.emit('raw', message);
@@ -1030,7 +1031,7 @@ Client.prototype._updateMaxLineLength = function() {
  * takes a raw "line" from the IRC server and turns it into an object with
  * useful keys
  */
-function parseMessage(line, stripColors) {
+exports.parseMessage = function(line, stripColors) {
     var message = {};
     var match;
 
@@ -1087,5 +1088,3 @@ function parseMessage(line, stripColors) {
 
     return message;
 }
-
-exports.parseMessage = parseMessage;


### PR DESCRIPTION
Export codes & parseMessage ( the parser ) so users can have more access to them.

parseMessage was already exported, but users couldn't 'monkey-patch' it to use a different parsing method.

This was users can use their own parser with the help of codes or just simply modify the parser in a different way to their liking.

Has no backwards compat issues either.