### PR TITLE
fix(parseMessage): Factor parseMessage to another file for decoupling.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -24,9 +24,8 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
 var colors = require('./colors');
+var parseMessage = require('./parse_message');
 exports.colors = colors;
-
-var replyFor = require('./codes');
 
 var lineDelimiter = new RegExp('\r\n|\r|\n')
 
@@ -1026,68 +1025,3 @@ Client.prototype._updateMaxLineLength = function() {
     // target is determined in _speak() and subtracted there
     this.maxLineLength = 497 - this.nick.length - this.hostMask.length;
 };
-/*
- * parseMessage(line, stripColors)
- *
- * takes a raw "line" from the IRC server and turns it into an object with
- * useful keys
- */
-function parseMessage(line, stripColors) {
-    var message = {};
-    var match;
-
-    if (stripColors) {
-        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
-    }
-
-    // Parse prefix
-    match = line.match(/^:([^ ]+) +/);
-    if (match) {
-        message.prefix = match[1];
-        line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
-        if (match) {
-            message.nick = match[1];
-            message.user = match[3];
-            message.host = match[4];
-        }
-        else {
-            message.server = message.prefix;
-        }
-    }
-
-    // Parse command
-    match = line.match(/^([^ ]+) */);
-    message.command = match[1];
-    message.rawCommand = match[1];
-    message.commandType = 'normal';
-    line = line.replace(/^[^ ]+ +/, '');
-
-    if (replyFor[message.rawCommand]) {
-        message.command     = replyFor[message.rawCommand].name;
-        message.commandType = replyFor[message.rawCommand].type;
-    }
-
-    message.args = [];
-    var middle, trailing;
-
-    // Parse parameters
-    if (line.search(/^:|\s+:/) != -1) {
-        match = line.match(/(.*?)(?:^:|\s+:)(.*)/);
-        middle = match[1].trimRight();
-        trailing = match[2];
-    }
-    else {
-        middle = line;
-    }
-
-    if (middle.length)
-        message.args = middle.split(/ +/);
-
-    if (typeof (trailing) != 'undefined' && trailing.length)
-        message.args.push(trailing);
-
-    return message;
-}
-
-exports.parseMessage = parseMessage;

--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -1,0 +1,68 @@
+var replyFor = require('./codes');
+
+/**
+ * parseMessage(line, stripColors)
+ *
+ * takes a raw "line" from the IRC server and turns it into an object with
+ * useful keys
+ * @param {String} line Raw message from IRC server.
+ * @param {Boolean} stripColors If true, strip IRC colors.
+ * @return {Object} A parsed message object.
+ */
+module.exports = function parseMessage(line, stripColors) {
+    var message = {};
+    var match;
+
+    if (stripColors) {
+        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
+    }
+
+    // Parse prefix
+    match = line.match(/^:([^ ]+) +/);
+    if (match) {
+        message.prefix = match[1];
+        line = line.replace(/^:[^ ]+ +/, '');
+        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        if (match) {
+            message.nick = match[1];
+            message.user = match[3];
+            message.host = match[4];
+        }
+        else {
+            message.server = message.prefix;
+        }
+    }
+
+    // Parse command
+    match = line.match(/^([^ ]+) */);
+    message.command = match[1];
+    message.rawCommand = match[1];
+    message.commandType = 'normal';
+    line = line.replace(/^[^ ]+ +/, '');
+
+    if (replyFor[message.rawCommand]) {
+        message.command     = replyFor[message.rawCommand].name;
+        message.commandType = replyFor[message.rawCommand].type;
+    }
+
+    message.args = [];
+    var middle, trailing;
+
+    // Parse parameters
+    if (line.search(/^:|\s+:/) != -1) {
+        match = line.match(/(.*?)(?:^:|\s+:)(.*)/);
+        middle = match[1].trimRight();
+        trailing = match[2];
+    }
+    else {
+        middle = line;
+    }
+
+    if (middle.length)
+        message.args = middle.split(/ +/);
+
+    if (typeof (trailing) != 'undefined' && trailing.length)
+        message.args.push(trailing);
+
+    return message;
+}

--- a/test/test-parse-line.js
+++ b/test/test-parse-line.js
@@ -1,4 +1,4 @@
-var irc  = require('../lib/irc.js');
+var parseMessage  = require('../lib/parse_message');
 var test = require('tape');
 
 test('irc.parseMessage', function(t) {
@@ -92,7 +92,7 @@ test('irc.parseMessage', function(t) {
     Object.keys(checks).forEach(function(line) {
         t.equal(
             JSON.stringify(checks[line]),
-            JSON.stringify(irc.parseMessage(line)),
+            JSON.stringify(parseMessage(line)),
             line + ' parses correctly'
         );
     });


### PR DESCRIPTION
This is mostly is a first step to make the message parser less coupled with the main IRC lib.

This is a no-op, cosmetic change.