### PR TITLE
feature(parser middleware): Add support for processing raw IRC lines.

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -31,3 +31,12 @@ function wrap(color, text, resetColor) {
     return text;
 }
 exports.wrap = wrap;
+
+/**
+ * Return a string with IRC colors stripped away.
+ * @param {String} line The IRC message.
+ * @return {String} An IRC message stripped of colors.
+ */
+exports.stripColors = function stripColors(line) {
+    return line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
+};

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -63,6 +63,12 @@ function Client(server, nick, opt) {
         }
     };
 
+    // Parser middlewares. Transform raw IRC lines before they make it to the parser.
+    self.parseMiddlewares = [];
+
+    // The default message parser.
+    self.parser = parseMessage;
+
     // Features supported by the server
     // (initial values are RFC 1459 defaults. Zeros signify
     // no default or unlimited value)
@@ -94,6 +100,10 @@ function Client(server, nick, opt) {
 
     if (self.opt.floodProtection) {
         self.activateFloodProtection();
+    }
+
+    if (self.opt.stripColors) {
+        self.enableParseMiddleware(colors.stripColors);
     }
 
     self.hostMask = '';
@@ -610,7 +620,6 @@ function Client(server, nick, opt) {
 
     EventEmitter.call(this);
 }
-
 util.inherits(Client, EventEmitter);
 
 Client.prototype.conn = null;
@@ -618,6 +627,7 @@ Client.prototype.prefixForMode = {};
 Client.prototype.modeForPrefix = {};
 Client.prototype.chans = {};
 Client.prototype._whoisData = {};
+
 Client.prototype.chanData = function(name, create) {
     var key = name.toLowerCase();
     if (create) {
@@ -749,8 +759,7 @@ Client.prototype.connect = function(retryCount, callback) {
         }
 
         lines.forEach(function iterator(line) {
-            var message = parseMessage(line, self.opt.stripColors);
-
+            var message = self.parseMessage(line);
             try {
                 self.emit('raw', message);
             } catch (err) {
@@ -790,6 +799,24 @@ Client.prototype.connect = function(retryCount, callback) {
         self.emit('netError', exception);
     });
 };
+
+Client.prototype.enableParseMiddleware = function(middleware) {
+    this.parseMiddlewares.push(middleware);
+};
+
+Client.prototype.disableParseMiddleware = function(middleware) {
+    this.parseMiddlewares = this.parseMiddlewares.filter(function(func) {
+        return func !== middleware;
+    });
+};
+
+Client.prototype.parseMessage = function(line) {
+    this.parseMiddlewares.forEach(function(middleware) {
+        line = middleware(line);
+    });
+    return this.parser(line);
+};
+
 Client.prototype.disconnect = function(message, callback) {
     if (typeof (message) === 'function') {
         callback = message;
@@ -813,6 +840,7 @@ Client.prototype.disconnect = function(message, callback) {
     }
     self.conn.end();
 };
+
 Client.prototype.send = function(command) {
     var args = Array.prototype.slice.call(arguments);
 
@@ -829,6 +857,7 @@ Client.prototype.send = function(command) {
         this.conn.write(args.join(' ') + '\r\n');
     }
 };
+
 Client.prototype.activateFloodProtection = function(interval) {
 
     var cmdQueue = [],
@@ -879,6 +908,7 @@ Client.prototype.join = function(channel, callback) {
     });
     this.send.apply(this, ['JOIN'].concat(channel.split(' ')));
 };
+
 Client.prototype.part = function(channel, message, callback) {
     if (typeof (message) === 'function') {
         callback = message;
@@ -900,6 +930,7 @@ Client.prototype.part = function(channel, message, callback) {
         this.send('PART', channel);
     }
 };
+
 Client.prototype.action = function(channel, text) {
     var self = this;
     if (typeof text !== 'undefined') {
@@ -910,6 +941,7 @@ Client.prototype.action = function(channel, text) {
         });
     }
 };
+
 Client.prototype._splitLongLines = function(words, maxLength, destination) {
     if (words.length < maxLength) {
         destination.push(words);
@@ -937,12 +969,15 @@ Client.prototype._splitLongLines = function(words, maxLength, destination) {
     destination.push(part);
     return this._splitLongLines(words.substring(cutPos + 1, words.length), maxLength, destination);
 };
+
 Client.prototype.say = function(target, text) {
     this._speak('PRIVMSG', target, text);
 };
+
 Client.prototype.notice = function(target, text) {
     this._speak('NOTICE', target, text);
 };
+
 Client.prototype._speak = function(kind, target, text) {
     var self = this;
     var maxLength = this.maxLineLength - target.length;
@@ -960,6 +995,7 @@ Client.prototype._speak = function(kind, target, text) {
         });
     }
 };
+
 Client.prototype.whois = function(nick, callback) {
     if (typeof callback === 'function') {
         var callbackWrapper = function(info) {
@@ -972,16 +1008,19 @@ Client.prototype.whois = function(nick, callback) {
     }
     this.send('WHOIS', nick);
 };
+
 Client.prototype.list = function() {
     var args = Array.prototype.slice.call(arguments, 0);
     args.unshift('LIST');
     this.send.apply(this, args);
 };
+
 Client.prototype._addWhoisData = function(nick, key, value, onlyIfExists) {
     if (onlyIfExists && !this._whoisData[nick]) return;
     this._whoisData[nick] = this._whoisData[nick] || {nick: nick};
     this._whoisData[nick][key] = value;
 };
+
 Client.prototype._clearWhoisData = function(nick) {
     // Ensure that at least the nick exists before trying to return
     this._addWhoisData(nick, 'nick', nick);
@@ -989,6 +1028,7 @@ Client.prototype._clearWhoisData = function(nick) {
     delete this._whoisData[nick];
     return data;
 };
+
 Client.prototype._handleCTCP = function(from, to, text, type, message) {
     text = text.slice(1);
     text = text.slice(0, text.indexOf('\u0001'));
@@ -1002,9 +1042,11 @@ Client.prototype._handleCTCP = function(from, to, text, type, message) {
     if (parts[0] === 'PING' && type === 'privmsg' && parts.length > 1)
         this.ctcp(from, 'notice', text);
 };
+
 Client.prototype.ctcp = function(to, type, text) {
     return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1' + text + '\1');
 };
+
 Client.prototype.convertEncoding = function(str) {
     var self = this;
 
@@ -1019,6 +1061,7 @@ Client.prototype.convertEncoding = function(str) {
         return str;
     }
 };
+
 // blatantly stolen from irssi's splitlong.pl. Thanks, Bjoern Krombholz!
 Client.prototype._updateMaxLineLength = function() {
     // 497 = 510 - (":" + "!" + " PRIVMSG " + " :").length;

--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -13,8 +13,8 @@ module.exports = function parseMessage(line, stripColors) {
     var message = {};
     var match;
 
-    if (stripColors) {
-        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
+    if (!line) {
+        return message;
     }
 
     // Parse prefix

--- a/test/mockircd.js
+++ b/test/mockircd.js
@@ -28,8 +28,9 @@ var MockIrcd = function(port, encoding) {
             self.emit('end')
         });
     });
-
     this.server.listen(this.port);
+
+    EventEmitter.call(this);
 };
 util.inherits(MockIrcd, EventEmitter);
 

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -1,5 +1,3 @@
-var net = require('net');
-
 var irc = require('../lib/irc');
 var test = require('tape');
 
@@ -7,8 +5,6 @@ var MockIrcd = require('./mockircd');
 
 test('connect, register and quit', function(t) {
     var client, mock, expected;
-
-    t.plan(3);
 
     mock = MockIrcd();
     client = new irc.Client('localhost', 'testbot', {});

--- a/test/test-parse-middlewares.js
+++ b/test/test-parse-middlewares.js
@@ -1,0 +1,188 @@
+var util = require('util');
+
+var test = require('tape');
+
+var irc = require('../lib/irc');
+var colors = require('../lib/colors');
+var MockIrcd = require('./mockircd');
+
+test('filter message middleware', function(t) {
+    var client, mock, expected;
+
+    mock = MockIrcd();
+    client = new irc.Client('localhost', 'testbot', {});
+
+    client.enableParseMiddleware(function(line) {
+        if (line.indexOf('NODEBOT TEST MESSAGE') === -1) {
+            return line;
+        }
+        return '';
+    });
+
+    expected = {
+        sent: [
+            ['NICK testbot', 'Client sent NICK message'],
+            ['USER nodebot 8 * :nodeJS IRC client', 'Client sent USER message'],
+            ['QUIT :node-irc says goodbye', 'Client sent QUIT message']
+        ],
+
+        received: [
+            [':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n', 'Received welcome message']
+        ]
+    };
+
+    t.plan(expected.sent.length + expected.received.length);
+
+    mock.server.on('connection', function() {
+        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+        mock.send(':localhost 001 testbot :Welcome to the NODEBOT TEST MESSAGE testbot\r\n');
+    });
+
+    // The middleware should filter out the second welcome message, so if the registered event
+    // is called more than once, the test will fail due to more tests than planned being run
+    client.on('registered', function() {
+        t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);
+        client.disconnect();
+    });
+
+    mock.on('end', function() {
+        var msgs = mock.getIncomingMsgs();
+
+        for (var i = 0; i < msgs.length; i++) {
+            t.equal(msgs[i], expected.sent[i][0], expected.sent[i][1]);
+        }
+        mock.close();
+    });
+});
+
+test('stripColor middleware with option', function(t) {
+    var client, mock, expected, colorMessages = [], colorNames = [];
+
+    mock = MockIrcd();
+    client = new irc.Client('localhost', 'testbot', {stripColors: true});
+    colorNames = Object.keys(colors.codes);
+
+    expected = {
+        sent: [
+            ['NICK testbot', 'Client sent NICK message'],
+            ['USER nodebot 8 * :nodeJS IRC client', 'Client sent USER message'],
+            ['QUIT :node-irc says goodbye', 'Client sent QUIT message']
+        ],
+
+        received: [
+            [':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n', 'Received welcome message']
+        ],
+
+        messageText: []
+    };
+
+    colorNames.forEach(function(name) {
+        expected.received.push([
+            util.format(':jirwin!~jirwin@unaffiliated/jirwin PRIVMSG ##node-irc %s%s\r\n', colors.codes[name], name),
+            util.format('Received message with %s color code in it', name)
+        ]);
+
+        expected.messageText.push([name, util.format('%s color code was properly stripped', name)]);
+    });
+
+    mock.server.on('connection', function() {
+        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+    });
+
+    client.on('registered', function() {
+        t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);
+        colorNames.forEach(function(name) {
+            mock.send(util.format(':jirwin!~jirwin@unaffiliated/jirwin PRIVMSG ##node-irc %s%s\r\n', colors.codes[name], name));
+        });
+        client.disconnect();
+    });
+
+    client.on('message', function(from, to, text, type, message) {
+        colorMessages.push(text);
+    });
+
+    mock.on('end', function() {
+        var msgs = mock.getIncomingMsgs();
+
+        t.equal(msgs.length, expected.sent.length, 'Sent the same number of messages to the IRC server as we expected');
+        for (var i = 0; i < msgs.length; i++) {
+            t.equal(msgs[i], expected.sent[i][0], expected.sent[i][1]);
+        }
+
+        t.equal(colorMessages.length, expected.messageText.length,
+                'Received the same number of color messages as we expected');
+        for (i = 0; i < colorMessages.length; i++) {
+            t.equal(colorMessages[i], expected.messageText[i][0], expected.messageText[i][1]);
+        }
+
+        t.end();
+        mock.close();
+    });
+});
+
+test('stripColor middleware manually added', function(t) {
+    var client, mock, expected, colorMessages = [], colorNames = [];
+
+    mock = MockIrcd();
+    client = new irc.Client('localhost', 'testbot', {});
+    colorNames = Object.keys(colors.codes);
+
+    client.enableParseMiddleware(colors.stripColors);
+
+    expected = {
+        sent: [
+            ['NICK testbot', 'Client sent NICK message'],
+            ['USER nodebot 8 * :nodeJS IRC client', 'Client sent USER message'],
+            ['QUIT :node-irc says goodbye', 'Client sent QUIT message']
+        ],
+
+        received: [
+            [':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n', 'Received welcome message']
+        ],
+
+        messageText: []
+    };
+
+    colorNames.forEach(function(name) {
+        expected.received.push([
+            util.format(':jirwin!~jirwin@unaffiliated/jirwin PRIVMSG ##node-irc %s%s\r\n', colors.codes[name], name),
+            util.format('Received message with %s color code in it', name)
+        ]);
+
+        expected.messageText.push([name, util.format('%s color code was properly stripped', name)]);
+    });
+
+    mock.server.on('connection', function() {
+        mock.send(':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n');
+    });
+
+    client.on('registered', function() {
+        t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);
+        colorNames.forEach(function(name) {
+            mock.send(util.format(':jirwin!~jirwin@unaffiliated/jirwin PRIVMSG ##node-irc %s%s\r\n', colors.codes[name], name));
+        });
+        client.disconnect();
+    });
+
+    client.on('message', function(from, to, text, type, message) {
+        colorMessages.push(text);
+    });
+
+    mock.on('end', function() {
+        var msgs = mock.getIncomingMsgs();
+
+        t.equal(msgs.length, expected.sent.length, 'Sent the same number of messages to the IRC server as we expected');
+        for (var i = 0; i < msgs.length; i++) {
+            t.equal(msgs[i], expected.sent[i][0], expected.sent[i][1]);
+        }
+
+        t.equal(colorMessages.length, expected.messageText.length,
+                'Received the same number of color messages as we expected');
+        for (i = 0; i < colorMessages.length; i++) {
+            t.equal(colorMessages[i], expected.messageText[i][0], expected.messageText[i][1]);
+        }
+
+        t.end();
+        mock.close();
+    });
+});


### PR DESCRIPTION
This introduces a change that allows users to process any incoming raw
IRC messages before they are passed onto the final message parser.

This adds a few concepts:
* `Client.enableParseMiddleware(function)`: Add a function to the end of
  the middleware chain.
* `Client.disableParseMiddleware(function`: Removes a function from the
   middleware chain.
* `Client.parser`: The function that is used to parsed an incoming raw
  IRC message. This is run after all middlewares have completed.
  Defaults to the message parser at `./lib/parse_message.js`. Custome
  parsers must return an object that matches what the existing parser
  returns.

As an example, the stripColors feature has been moved to a parser
middleware.

Also tests.