### PR TITLE
do not autorejoin on kicks. bad bot! no cookie!

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -22,7 +22,7 @@ Client
             localAddress: null,
             debug: false,
             showErrors: false,
-            autoRejoin: true,
+            autoRejoin: false,
             autoConnect: true,
             channels: [],
             secure: false,

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -41,7 +41,7 @@ function Client(server, nick, opt) {
         localAddress: null,
         debug: false,
         showErrors: false,
-        autoRejoin: true,
+        autoRejoin: false,
         autoConnect: true,
         channels: [],
         retryCount: null,


### PR DESCRIPTION
autorejoin is the cancer that is killing IRC.