### PR TITLE
Bring in irc-colors for stripping colors

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -1,3 +1,4 @@
+var ircColors = require('irc-colors');
 var replyFor = require('./codes');
 
 /**
@@ -14,7 +15,7 @@ module.exports = function parseMessage(line, stripColors) {
     var match;
 
     if (stripColors) {
-        line = line.replace(/[\x02\x1f\x16\x0f]|\x03\d{0,2}(?:,\d{0,2})?/g, '');
+        line = ircColors.stripColorsAndStyle(line);
     }
 
     // Parse prefix

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     }
   ],
   "dependencies": {
-    "ansi-color": "0.2.1"
+    "ansi-color": "0.2.1",
+    "irc-colors": "^1.1.0"
   },
   "optionalDependencies": {
     "iconv": "~2.1.4",

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -87,6 +87,28 @@
 			"commandType": "normal",
 			"args": ["#channel", "so : colons: :are :: not a problem ::::"]
 		},
+		":nick!user@host PRIVMSG #channel :\u000314,01\u001fneither are colors or styles\u001f\u0003": {
+			"prefix": "nick!user@host",
+			"nick": "nick",
+			"user": "user",
+			"host": "host",
+			"command": "PRIVMSG",
+			"rawCommand": "PRIVMSG",
+			"commandType": "normal",
+			"args": ["#channel", "neither are colors or styles"],
+			"stripColors": true
+		},
+		":nick!user@host PRIVMSG #channel :\u000314,01\u001fwe can leave styles and colors alone if desired\u001f\u0003": {
+			"prefix": "nick!user@host",
+			"nick": "nick",
+			"user": "user",
+			"host": "host",
+			"command": "PRIVMSG",
+			"rawCommand": "PRIVMSG",
+			"commandType": "normal",
+			"args": ["#channel", "\u000314,01\u001fwe can leave styles and colors alone if desired\u001f\u0003"],
+			"stripColors": false
+		},
 		":pratchett.freenode.net 324 nodebot #ubuntu +CLcntjf 5:10 #ubuntu-unregged": {
 			"prefix": "pratchett.freenode.net",
 			"server": "pratchett.freenode.net",

--- a/test/test-parse-line.js
+++ b/test/test-parse-line.js
@@ -7,9 +7,14 @@ test('irc.parseMessage', function(t) {
     var checks = testHelpers.getFixtures('parse-line');
 
     Object.keys(checks).forEach(function(line) {
+        var stripColors = false;
+        if (checks[line].hasOwnProperty('stripColors')) {
+            stripColors = checks[line].stripColors;
+            delete checks[line].stripColors;
+        }
         t.equal(
             JSON.stringify(checks[line]),
-            JSON.stringify(parseMessage(line)),
+            JSON.stringify(parseMessage(line, stripColors)),
             line + ' parses correctly'
         );
     });


### PR DESCRIPTION
This doesn't touch the formatting stuff, because it's not really
feasible to do that cleanly in an API-compatible way, and I think
that the user is better off doing that in their own code anyway.
This closes #297.