### PR TITLE
Fix bug where bytes are lost from long strings with no whitespace

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -919,14 +919,18 @@ Client.prototype.action = function(channel, text) {
 };
 
 Client.prototype._splitLongLines = function(words, maxLength, destination) {
-    if (words.length < maxLength) {
+    if (words.length == 0) {
+        return destination;
+    }
+    if (words.length <= maxLength) {
         destination.push(words);
         return destination;
     }
-    var c = words[maxLength - 1];
+    var c = words[maxLength];
     var cutPos;
+    var wsLength = 1;
     if (c.match(/\s/)) {
-        cutPos = maxLength - 1;
+        cutPos = maxLength;
     } else {
         var offset = 1;
         while ((maxLength - offset) > 0) {
@@ -939,11 +943,12 @@ Client.prototype._splitLongLines = function(words, maxLength, destination) {
         }
         if (maxLength - offset <= 0) {
             cutPos = maxLength;
+            wsLength = 0;
         }
     }
     var part = words.substring(0, cutPos);
     destination.push(part);
-    return this._splitLongLines(words.substring(cutPos + 1, words.length), maxLength, destination);
+    return this._splitLongLines(words.substring(cutPos + wsLength, words.length), maxLength, destination);
 };
 
 Client.prototype.say = function(target, text) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "xAndy <xandy@hackerspace-bamberg.de>",
     "Mischa Spiegelmock <revmischa@cpan.org>",
     "Justin Gallardo <justin.gallardo@gmail.com>",
-    "Chris Nehren <cnehren@pobox.com>"
+    "Chris Nehren <cnehren@pobox.com>",
+    "Alex Miles <ghostaldev@gmail.com>"
   ],
   "repository": {
     "type": "git",

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -136,5 +136,27 @@
 			"nick is as expected after 433",
 			"maxLineLength is as expected after 433"
 		]
-	}
+	},
+    "_splitLongLines": [
+        {
+            "input": "abcde ",
+            "maxLength": 5,
+            "result": ["abcde"]
+        },
+        {
+            "input": "abcde",
+            "maxLength": 5,
+            "result": ["abcde"]
+        },
+        {
+            "input": "abcdefghijklmnopqrstuvwxyz",
+            "maxLength": 5,
+            "result": ["abcde", "fghij", "klmno", "pqrst", "uvwxy", "z"]
+        },
+        {
+            "input": "abc abcdef abc abcd abc",
+            "maxLength": 5,
+            "result": ["abc", "abcde", "f abc", "abcd", "abc"]
+        }
+    ]
 }

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -65,3 +65,22 @@ function runTests(t, isSecure, useSecureObject) {
         mock.close();
     });
 }
+
+test ('splitting of long lines', function(t) {
+    var port = 6667;
+    var mock = testHelpers.MockIrcd(port, 'utf-8', false);
+    var client = new irc.Client('localhost', 'testbot', {
+        secure: false,
+        selfSigned: true,
+        port: port,
+        retryCount: 0,
+        debug: true
+    });
+
+    var group = testHelpers.getFixtures('_splitLongLines');
+    t.plan(group.length);
+    group.forEach(function(item) {
+        t.deepEqual(client._splitLongLines(item.input, item.maxLength, []), item.result);
+    });
+    mock.close();
+});


### PR DESCRIPTION
In the case that whitespace was found for splitting the string, it
makes sense to avoid sending it at the start of the next line.
However, if no whitespace was found, the starting position of the
next call should not be shifted forward.