### PR TITLE
Fix option handling when passing a secure object

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -662,8 +662,7 @@ Client.prototype.connect = function(retryCount, callback) {
         if (typeof self.opt.secure == 'object') {
             // copy "secure" opts to options passed to connect()
             for (var f in self.opt.secure) {
-                if (creds.hasOwnProperty(f))
-                    connectionOpts[f] = self.opt.secure[f];
+                connectionOpts[f] = self.opt.secure[f];
             }
         }
 

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -9,23 +9,41 @@ var expected = testHelpers.getFixtures('basic');
 var greeting = ':localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n';
 
 test('connect, register and quit', function(t) {
-    runTests(t, false);
+    runTests(t, false, false);
 });
 
 test('connect, register and quit, securely', function(t) {
-    runTests(t, true);
+    runTests(t, true, false);
 });
 
-function runTests(t, isSecure) {
+test('connect, register and quit, securely, with secure object', function(t) {
+    runTests(t, true, true);
+});
+
+function runTests(t, isSecure, useSecureObject) {
     var port = isSecure ? 6697 : 6667;
     var mock = testHelpers.MockIrcd(port, 'utf-8', isSecure);
-    var client = new irc.Client('localhost', 'testbot', {
-        secure: isSecure,
-        selfSigned: true,
-        port: port,
-        retryCount: 0,
-        debug: true
-    });
+    var client;
+    if (isSecure && useSecureObject) {
+        client = new irc.Client('notlocalhost', 'testbot', {
+            secure: {
+                host: 'localhost',
+                port: port,
+                rejectUnauthorized: false
+            },
+            selfSigned: true,
+            retryCount: 0,
+            debug: true
+        });
+    } else {
+        var client = new irc.Client('localhost', 'testbot', {
+            secure: isSecure,
+            selfSigned: true,
+            port: port,
+            retryCount: 0,
+            debug: true
+        });
+    }
 
     t.plan(expected.sent.length + expected.received.length);
 


### PR DESCRIPTION
This was left over from fixing the SSL connection issues. Add a
test as well to ensure it works now and to ensure it doesn't
break in future.