### PR TITLE
Add CAP REQ support for users hopefully without breaking anything

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -56,6 +56,7 @@ function Client(server, nick, opt) {
         channelPrefixes: '&#',
         messageSplit: 512,
         encoding: false,
+        isUserIdentified: false,
         webirc: {
           pass: '',
           ip: '',
@@ -561,6 +562,9 @@ function Client(server, nick, opt) {
                      message.args[1] === 'ACK' &&
                      message.args[2] === 'sasl ') // there's a space after sasl
                     self.send('AUTHENTICATE', 'PLAIN');
+                if (self.opt.isUserIdentified) {
+                    self.send("CAP", "END");
+                }
                 break;
             case 'AUTHENTICATE':
                 if (message.args[0] === '+') self.send('AUTHENTICATE',
@@ -714,6 +718,9 @@ Client.prototype.connect = function(retryCount, callback) {
     }
 
     self.conn.addListener('connect', function() {
+        if (self.opt.isUserIdentified) {
+          self.send("CAP REQ", "identify-msg");
+        }
         if (self.opt.sasl) {
             // see http://ircv3.atheme.org/extensions/sasl-3.1
             self.send('CAP REQ', 'sasl');


### PR DESCRIPTION
If enabled and server supports it, the option should add '+' to the nick if user is authenticated or '-' if not. Works on Freenode.

Hopefully it won't break anything.