### PR TITLE
fix blank lines being passed to parse message

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -749,13 +749,15 @@ Client.prototype.connect = function(retryCount, callback) {
         }
 
         lines.forEach(function iterator(line) {
-            var message = parseMessage(line, self.opt.stripColors);
+            if (line.length) {
+                var message = parseMessage(line, self.opt.stripColors);
 
-            try {
-                self.emit('raw', message);
-            } catch (err) {
-                if (!self.conn.requestedDisconnect) {
-                    throw err;
+                try {
+                    self.emit('raw', message);
+                } catch (err) {
+                    if (!self.conn.requestedDisconnect) {
+                        throw err;
+                    }
                 }
             }
         });

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -10,6 +10,17 @@
 			[":localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n", "Received welcome message"]
 		]
 	},
+	"double-CRLF": {
+		"sent": [
+			["NICK testbot", "Client sent NICK message"],
+			["USER nodebot 8 * :nodeJS IRC client", "Client sent USER message"],
+			["QUIT :node-irc says goodbye", "Client sent QUIT message"]
+		],
+
+		"received": [
+			[":localhost 001 testbot :Welcome to the Internet Relay Chat Network testbot\r\n\r\n", "Received welcome message"]
+		]
+	},
 	"parse-line": {
 		":irc.dollyfish.net.nz 372 nodebot :The message of the day was last changed: 2012-6-16 23:57": {
 			"prefix": "irc.dollyfish.net.nz",

--- a/test/test-double-crlf.js
+++ b/test/test-double-crlf.js
@@ -1,0 +1,33 @@
+var net = require('net');
+
+var irc = require('../lib/irc');
+var test = require('tape');
+
+var testHelpers = require('./helpers');
+
+test('sent messages ending with double CRLF', function(t) {
+    var mock = testHelpers.MockIrcd();
+    var client = new irc.Client('localhost', 'testbot', { debug: true});
+
+    var expected = testHelpers.getFixtures('double-CRLF');
+
+    t.plan(expected.sent.length + expected.received.length);
+
+    mock.server.on('connection', function() {
+        mock.send(expected.received[0][0]);
+    });
+
+    client.on('registered', function() {
+        t.equal(mock.outgoing[0], expected.received[0][0], expected.received[0][1]);
+        client.disconnect();
+    });
+
+    mock.on('end', function() {
+        var msgs = mock.getIncomingMsgs();
+
+        for (var i = 0; i < msgs.length; i++) {
+            t.equal(msgs[i], expected.sent[i][0], expected.sent[i][1]);
+        }
+        mock.close();
+    });
+});


### PR DESCRIPTION
I was using this to interact with twitch irc and it kept crashing because the service occasionally sends a double line break at the end of a line, this was an easy fix but I'm not sure it's in the right place. Feel free to refuse it.