### PR TITLE
Add localPort connection option to specify socket bind port

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -20,6 +20,7 @@ Client
             realName: 'nodeJS IRC client',
             port: 6667,
             localAddress: null,
+            localPort: null,
             debug: false,
             showErrors: false,
             autoRejoin: false,
@@ -42,7 +43,9 @@ Client
     If you set `selfSigned` to true SSL accepts certificates from a non trusted CA.
     If you set `certExpired` to true, the bot connects even if the ssl cert has expired.
 
-    `localAddress` is the address to bind to when connecting.
+    `localAddress` is the local address to bind to when connecting, such as `127.0.0.1`
+    
+    `localPort` is the local port to bind when connecting, such as `50555`
 
     `floodProtection` queues all your messages and slowly unpacks it to make sure
     that we won't get kicked out because for Excess Flood. You can also use

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -39,6 +39,7 @@ function Client(server, nick, opt) {
         realName: 'nodeJS IRC client',
         port: 6667,
         localAddress: null,
+        localPort: null,
         debug: false,
         showErrors: false,
         autoRejoin: false,
@@ -654,6 +655,8 @@ Client.prototype.connect = function(retryCount, callback) {
     // local address to bind to
     if (self.opt.localAddress)
         connectionOpts.localAddress = self.opt.localAddress;
+    if (self.opt.localPort)
+        connectionOpts.localPort = self.opt.localPort;
 
     // try to connect to the server
     if (self.opt.secure) {


### PR DESCRIPTION
... when connecting, the same way it's done with localAddress.

Node added support for this on v0.11.13+, see [issue 7092](https://github.com/joyent/node/issues/7092)