### PR TITLE
node-icu-charset-detector version bump for node 0.12 (issue #332)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "optionalDependencies": {
     "iconv": "~2.1.4",
-    "node-icu-charset-detector": "0.0.7"
+    "node-icu-charset-detector": "0.1.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",


### PR DESCRIPTION
node-icu-charset-detector version 0.0.7 isn't compatible with node 0.12.0
Update to 0.1.0 seems to fix the problem.