### PR TITLE
Fixed case sensitivity bug in client.whois()

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -977,7 +977,7 @@ Client.prototype._speak = function(kind, target, text) {
 Client.prototype.whois = function(nick, callback) {
     if (typeof callback === 'function') {
         var callbackWrapper = function(info) {
-            if (info.nick == nick) {
+            if (info.nick.toLowerCase() == nick.toLowerCase()) {
                 this.removeListener('whois', callbackWrapper);
                 return callback.apply(this, arguments);
             }


### PR DESCRIPTION
This is a simple fix to ensure whois callbacks are fired when a user's name is capitalized differently than the whois response. Currently, a whois callback will never be fired unless the whois nick exactly matches.

For example, if a user "Rachel" is connected to IRC:

```
client.whois("rachel", function() {
    // This callback is never fired, because "rachel" != "Rachel"
});
```

This pull request partially solves issue #322 