### PR TITLE
Fix double connect event when using SSL

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -705,6 +705,21 @@ Client.prototype.connect = function(retryCount, callback) {
         });
     } else {
         self.conn = net.createConnection(connectionOpts);
+        self.conn.addListener('connect', function() {
+            if (self.opt.sasl) {
+                // see http://ircv3.atheme.org/extensions/sasl-3.1
+                self.send('CAP REQ', 'sasl');
+            }
+            if (self.opt.webirc.ip && self.opt.webirc.pass && self.opt.webirc.host) {
+                self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
+            } else if (self.opt.password) {
+                self.send('PASS', self.opt.password);
+            }
+            self.send('NICK', self.opt.nick);
+            self.nick = self.opt.nick;
+            self.send('USER', self.opt.userName, 8, '*', self.opt.realName);
+            self.emit('connect');
+        });
     }
     self.conn.requestedDisconnect = false;
     self.conn.setTimeout(0);
@@ -712,22 +727,6 @@ Client.prototype.connect = function(retryCount, callback) {
     if (!self.opt.encoding) {
         self.conn.setEncoding('utf8');
     }
-
-    self.conn.addListener('connect', function() {
-        if (self.opt.sasl) {
-            // see http://ircv3.atheme.org/extensions/sasl-3.1
-            self.send('CAP REQ', 'sasl');
-        }
-        if (self.opt.webirc.ip && self.opt.webirc.pass && self.opt.webirc.host) {
-            self.send('WEBIRC', self.opt.webirc.pass, self.opt.userName, self.opt.webirc.host, self.opt.webirc.ip);
-        } else if (self.opt.password) {
-            self.send('PASS', self.opt.password);
-        }
-        self.send('NICK', self.opt.nick);
-        self.nick = self.opt.nick;
-        self.send('USER', self.opt.userName, 8, '*', self.opt.realName);
-        self.emit('connect');
-    });
 
     var buffer = new Buffer('');
 


### PR DESCRIPTION
Hey, I noticed that whenever I tried to connect securely to OFTC, the client would crash with a 462 ERR_ALREADYREGISTRED. The client seemed to be sending NICK/USER commands twice, but only when SSL was enabled.

My quick fix is to move the regular 'connect' listener so it only gets added when the 'secure' option is false. It seems to work, though I'm still not 100% sure if it will have other consequences.

Submitted for your perusal. Thanks!