### PR TITLE
Fix for unreal ircd, when a channel has +u (auditorium)

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -269,7 +269,7 @@ function Client(server, nick, opt) {
                         // channel user modes
                         var user = modeArgs.shift();
                         if (adding) {
-                            if (channel.users[user].indexOf(self.prefixForMode[mode]) === -1)
+                            if (channels.users[user] && channel.users[user].indexOf(self.prefixForMode[mode]) === -1)
                                 channel.users[user] += self.prefixForMode[mode];
 
                             self.emit('+mode', message.args[0], message.nick, mode, user, message);


### PR DESCRIPTION
When a channel on unreal ircd has +u a user might join the channel and get opped. In which case the JOIN event is never emmited to node-irc, but the +o event is.