### PR TITLE
Fix charset conversion for invalid charsets 

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1026,18 +1026,25 @@ Client.prototype.ctcp = function(to, type, text) {
 };
 
 Client.prototype.convertEncoding = function(str) {
-    var self = this;
+    var self = this, out = str;
 
     if (self.opt.encoding) {
-        var charsetDetector = require('node-icu-charset-detector');
-        var Iconv = require('iconv').Iconv;
-        var charset = charsetDetector.detectCharset(str).toString();
-        var to = new Iconv(charset, self.opt.encoding);
+        try {
+            var charsetDetector = require('node-icu-charset-detector');
+            var Iconv = require('iconv').Iconv;
+            var charset = charsetDetector.detectCharset(str);
+            var converter = new Iconv(charset.toString(), self.opt.encoding);
 
-        return to.convert(str);
-    } else {
-        return str;
+            out = converter.convert(str);
+        } catch (err) {
+            if (self.opt.debug) {
+                util.log('\u001b[01;31mERROR: ' + err + '\u001b[0m');
+                util.inspect({ str: str, charset: charset });
+            }
+        }
     }
+
+    return out;
 };
 // blatantly stolen from irssi's splitlong.pl. Thanks, Bjoern Krombholz!
 Client.prototype._updateMaxLineLength = function() {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "xAndy <xandy@hackerspace-bamberg.de>",
     "Mischa Spiegelmock <revmischa@cpan.org>",
     "Justin Gallardo <justin.gallardo@gmail.com>",
-    "Chris Nehren <cnehren@pobox.com>"
+    "Chris Nehren <cnehren@pobox.com>",
+    "Henri Niemeläinen <aivot-on@iki.fi>"
   ],
   "repository": {
     "type": "git",

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -147,5 +147,13 @@
 			"nick is as expected after 433",
 			"maxLineLength is as expected after 433"
 		]
-	}
+	},
+    "convert-encoding": {
+        "causesException": [
+            ":ubottu!ubottu@ubuntu/bot/ubottu MODE #ubuntu -bo *!~Brian@* ubottu\r\n",
+            "Elizabeth",
+            ":sblack1!~sblack1@unaffiliated/sblack1 NICK :sblack\r\n",
+            ":TijG!~TijG@null.1ago.be PRIVMSG #ubuntu :ThinkPad\r\n"
+        ]
+    }
 }

--- a/test/test-convert-encoding.js
+++ b/test/test-convert-encoding.js
@@ -1,0 +1,53 @@
+var irc = require('../lib/irc');
+var test = require('tape');
+var testHelpers = require('./helpers');
+var checks = testHelpers.getFixtures('convert-encoding');
+var bindTo = { opt: { encoding: 'utf-8' } };
+
+test('irc.Client.convertEncoding old', function(assert) {
+    var convertEncoding = function(str) {
+        var self = this;
+
+        if (self.opt.encoding) {
+            var charsetDetector = require('node-icu-charset-detector');
+            var Iconv = require('iconv').Iconv;
+            var charset = charsetDetector.detectCharset(str).toString();
+            var to = new Iconv(charset, self.opt.encoding);
+
+            return to.convert(str);
+        } else {
+            return str;
+        }
+    }.bind(bindTo);
+
+    checks.causesException.forEach(function iterate(line) {
+        var causedException = false;
+        try {
+            convertEncoding(line);
+        } catch (e) {
+            causedException = true;
+        }
+
+        assert.equal(causedException, true, line + ' caused exception');
+    });
+
+    assert.end();
+});
+
+test('irc.Client.convertEncoding', function(assert) {
+    var convertEncoding = irc.Client.prototype.convertEncoding.bind(bindTo);
+
+    checks.causesException.forEach(function iterate(line) {
+        var causedException = false;
+
+        try {
+            convertEncoding(line);
+        } catch (e) {
+            causedException = true;
+        }
+
+        assert.equal(causedException, false, line + ' didn\'t cause exception');
+    });
+
+    assert.end();
+});


### PR DESCRIPTION
For example string 'Elizabeth' passed through icu-charset-detector returns charset ibm424_rtl and Iconv cannot convert from ibm424_rtl to utf8. Enclosing the charset conversion inside try catch and returning the original buffer if it throws any errors so that it doesn't crash.