### PR TITLE
Travis: Sort supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.12"
   - "0.10"
+  - "0.12"
   - "iojs"
 before_install:
   - sudo apt-get -y install libicu-dev


### PR DESCRIPTION
- this way, we first run tests on older node (0.10.x), which is still installed
on majority of computers.