### PR TITLE
fix QUIT: "channels" shouldn't contain all channels of the bot

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -547,8 +547,11 @@ function Client(server, nick, opt) {
                 // TODO better way of finding what channels a user is in?
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    delete channel.users[message.nick];
-                    channels.push(channame);
+                    if (channel.users[message.nick] != undefined)
+                    {
+                        delete channel.users[message.nick];
+                        channels.push(channame);
+                    }
                 });
 
                 // who, reason, channels


### PR DESCRIPTION
channels should only contain channels where the quitting user was joined, not all the channels the bot is connected to