### PR TITLE
Safeguard channel user MODE changes (fixes #364)

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -268,15 +268,17 @@ function Client(server, nick, opt) {
                     if (mode in self.prefixForMode) {
                         // channel user modes
                         var user = modeArgs.shift();
-                        if (adding) {
-                            if (channel.users[user] && channel.users[user].indexOf(self.prefixForMode[mode]) === -1)
-                                channel.users[user] += self.prefixForMode[mode];
+                        if (user in channel.users) { // protect against misbehaving IRCd-s
+                            if (adding) {
+                                if (channel.users[user] && channel.users[user].indexOf(self.prefixForMode[mode]) === -1)
+                                    channel.users[user] += self.prefixForMode[mode];
 
-                            self.emit('+mode', message.args[0], message.nick, mode, user, message);
-                        }
-                        else {
-                            channel.users[user] = channel.users[user].replace(self.prefixForMode[mode], '');
-                            self.emit('-mode', message.args[0], message.nick, mode, user, message);
+                                self.emit('+mode', message.args[0], message.nick, mode, user, message);
+                            }
+                            else {
+                                channel.users[user] = channel.users[user].replace(self.prefixForMode[mode], '');
+                                self.emit('-mode', message.args[0], message.nick, mode, user, message);
+                            }
                         }
                     }
                     else {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Justin Gallardo <justin.gallardo@gmail.com>",
     "Chris Nehren <cnehren@pobox.com>",
     "Henri Niemeläinen <aivot-on@iki.fi>",
-    "Alex Miles <ghostaldev@gmail.com>"
+    "Alex Miles <ghostaldev@gmail.com>",
+    "Simmo Saan <simmo.saan@gmail.com>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently some IRCd-s like sending channel user mode removals on user PART (notably Twitch). This patch solves the issue by checking for user existence in channel before attempting to manipulate anything. Also no mode events will be emitted for such illegal MODE commands so that event listeners wouldn't need to do the same checks.

The change has been successfully tested in #364.