### PR TITLE
SyntaxError: Octal literals are not allowed in strict mode.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -581,7 +581,7 @@ function Client(server, nick, opt) {
 
             case 'err_erroneusnickname':
                 if (self.opt.showErrors)
-                    util.log('\033[01;31mERROR: ' + util.inspect(message) + '\033[0m');
+                    util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 self.emit('error', message);
                 break;
 
@@ -1016,7 +1016,7 @@ Client.prototype._handleCTCP = function(from, to, text, type, message) {
 };
 
 Client.prototype.ctcp = function(to, type, text) {
-    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\1' + text + '\1');
+    return this[type === 'privmsg' ? 'say' : 'notice'](to, '\u0001' + text + '\u0001');
 };
 
 Client.prototype.convertEncoding = function(str) {


### PR DESCRIPTION
node v0.12.1 --use-strict objects with 

    SyntaxError: Octal literals are not allowed in strict mode.

to the two lines affected by this PR.