### PR TITLE
Adding flexibility to client.say

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ talking:
 ```js
 client.say('#yourchannel', "I'm a bot!");
 client.say('nonbeliever', "SRSLY, I AM!");
+client.say(['#yourchannel', 'nonbeliever'], 'Believe me!');
+client.say('hello world!'); // messages all channels specified in options
 ```
 
 and many others. Check out the API documentation for a complete reference.

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -943,7 +943,14 @@ Client.prototype._splitLongLines = function(words, maxLength, destination) {
 };
 
 Client.prototype.say = function(target, text) {
-    this._speak('PRIVMSG', target, text);
+    var msg = text || target;
+    if (!Array.isArray(target)) {
+        if (!text) target = this.opt.channels;
+        else target = [target];
+    }
+    for (var i = 0; i < target.length; i++) {
+        this._speak('PRIVMSG', target[i], msg);
+    }
 };
 
 Client.prototype.notice = function(target, text) {


### PR DESCRIPTION
This change allows consumers to optionally pass an array to `.say()` or leave the out a target to automatically message all channels specified in options.