### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "licenses": [
-    {
-      "type": "GPL",
-      "url": "http://github.com/martynsmith/node-irc/raw/master/COPYING"
-    }
-  ],
+  "license": "GPL-3.0",
   "dependencies": {
     "ansi-color": "0.2.1",
     "irc-colors": "^1.1.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/