### PR TITLE
Support for CJK characters.

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,7 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^([_a-zA-Z0-9ᄀ-\u11fe\u3040-ゞ゠-ヾ\u3130-ㆎㇰ-ㇾ\ua960-\ua97e가-\ud7ae\ud7b0-\ud7fe\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -109,6 +109,17 @@
 			"args": ["#channel", "neither are colors or styles"],
 			"stripColors": true
 		},
+		":동우!~Arkind.DK@host PRIVMSG #channel :test message": {
+			"prefix": "동우!~Arkind.DK@host",
+			"nick": "동우",
+			"user": "~Arkind.DK",
+			"host": "host",
+			"command": "PRIVMSG",
+			"rawCommand": "PRIVMSG",
+			"commandType": "normal",
+			"args": ["#channel", "test message"],
+			"stripColors": true
+		},
 		":nick!user@host PRIVMSG #channel :\u000314,01\u001fwe can leave styles and colors alone if desired\u001f\u0003": {
 			"prefix": "nick!user@host",
 			"nick": "nick",


### PR DESCRIPTION
Many asian IRC servers support CJK characters in nicknames.

From RFC2812(https://tools.ietf.org/html/rfc2812#section-2.3.1), nickname should be
```
nickname   =  ( letter / special ) *8( letter / digit / special / "-" )
letter     =  %x41-5A / %x61-7A       ; A-Z / a-z
digit      =  %x30-39                 ; 0-9 
hexdigit   =  digit / "A" / "B" / "C" / "D" / "E" / "F"
special    =  %x5B-60 / %x7B-7D
                 ; "[", "]", "\", "`", "_", "^", "{", "|", "}"
```

But, I think RFC2812 is too old, and it should support other unicode characters.

I found issue #104 closed several years ago. @outsideris reported it.

I put the regexp generated from http://apps.timwhitlock.info/js/regex#, it contains CJK(Chinese, Japanese, Korean) regexp.