### PR TITLE
Add support for manual casemapping.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -80,7 +80,8 @@ function Client(server, nick, opt) {
         modes: 3,
         nicklength: 9,
         topiclength: 0,
-        usermodes: ''
+        usermodes: '',
+        casemapping: 'ascii'
     };
 
     if (typeof arguments[2] == 'object') {
@@ -140,6 +141,9 @@ function Client(server, nick, opt) {
                         var param = match[1];
                         var value = match[2];
                         switch (param) {
+                            case 'CASEMAPPING':
+                                self.supported.casemapping = value;
+                                break;
                             case 'CHANLIMIT':
                                 value.split(',').forEach(function(val) {
                                     val = val.split(':');
@@ -1046,3 +1050,25 @@ Client.prototype._updateMaxLineLength = function() {
     // target is determined in _speak() and subtracted there
     this.maxLineLength = 497 - this.nick.length - this.hostMask.length;
 };
+Client.prototype._toLowerCase = function(str) {
+    // http://www.irc.org/tech_docs/005.html
+    var knownCaseMappings = ['ascii', 'rfc1459', 'strict-rfc1459'];
+    if (knownCaseMappings.indexOf(this.supported.casemapping) === -1) {
+        return str;
+    }
+    var lower = str.toLowerCase();
+    if (this.supported.casemapping === 'rfc1459') {
+        lower = lower.
+        replace(/\[/g, '{').
+        replace(/\]/g, '}').
+        replace(/\\/g, '|').
+        replace(/\^/g, '~');
+    }
+    else if (this.supported.casemapping === 'strict-rfc1459') {
+        lower = lower.
+        replace(/\[/g, '{').
+        replace(/\]/g, '}').
+        replace(/\\/g, '|');
+    }
+    return lower;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Justin Gallardo <justin.gallardo@gmail.com>",
     "Chris Nehren <cnehren@pobox.com>",
     "Henri Niemeläinen <aivot-on@iki.fi>",
-    "Alex Miles <ghostaldev@gmail.com>"
+    "Alex Miles <ghostaldev@gmail.com>",
+    "Kegan Dougal <kegsay@gmail.com>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds support for the `isupport` option `CASEMAPPING` as outlined at http://www.irc.org/tech_docs/005.html

This does *not* alter any critical paths; it merely stores the case mapping and provides a function to get case-insensitive values for a given IRC server. Another PR may build off this to make this library entirely case-insensitive.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/martynsmith/node-irc/378)
<!-- Reviewable:end -->
