### PR TITLE
Respect opt.messageSplit when calculating message length

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1066,7 +1066,7 @@ Client.prototype.notice = function(target, text) {
 
 Client.prototype._speak = function(kind, target, text) {
     var self = this;
-    var maxLength = this.maxLineLength - target.length;
+    var maxLength = Math.min(this.maxLineLength - target.length, this.opt.messageSplit);
     if (typeof text !== 'undefined') {
         text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -183,5 +183,15 @@
 			"input": "abcdefghijklmnopqrstuvwxyz",
 			"result": ["abcdefghijklmnopqrstuvwxyz"]
 		}
+	],
+	"_speak": [
+		{
+			"length": 30,
+			"expected": 10
+		},
+		{
+			"length": 7,
+			"expected": 1
+		}
 	]
 }

--- a/test/test-irc.js
+++ b/test/test-irc.js
@@ -104,3 +104,29 @@ test ('splitting of long lines with no maxLength defined.', function(t) {
     });
     mock.close();
 });
+
+test ('opt.messageSplit used when set', function(t) {
+    var port = 6667;
+    var mock = testHelpers.MockIrcd(port, 'utf-8', false);
+    var client = new irc.Client('localhost', 'testbot', {
+        secure: false,
+        selfSigned: true,
+        port: port,
+        retryCount: 0,
+        debug: true,
+        messageSplit: 10
+    });
+
+    var group = testHelpers.getFixtures('_speak');
+    t.plan(group.length);
+    group.forEach(function(item) {
+        client.maxLineLength = item.length;
+        client._splitLongLines = function(words, maxLength, destination) {
+            t.equal(maxLength, item.expected);
+            return [words];
+        }
+        client._speak('kind', 'target', 'test message');
+    });
+
+    mock.close();
+});


### PR DESCRIPTION
At some point this got dropped out of the calculations. 
