### PR TITLE
Get the actual hostname from a whois call

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -128,6 +128,11 @@ function Client(server, nick, opt) {
                 self.hostMask = welcomeStringWords[welcomeStringWords.length - 1];
                 self._updateMaxLineLength();
                 self.emit('registered', message);
+                self.whois(self.nick, function(args) {
+                    self.nick = args.nick;
+                    self.hostMask = args.user + '@' + args.host;
+                    self._updateMaxLineLength();
+                });
                 break;
             case 'rpl_myinfo':
                 self.supported.usermodes = message.args[3];


### PR DESCRIPTION
Fixes #288. I'm pretty sure that the hostmask formulation is correct in general; it is correct for the servers I tested it against. 