### PR TITLE
Implements a (something)more robust encode conversion module

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,0 +1,38 @@
+util = require('util');
+
+module.exports.detect = function(str) {
+    // `jschardet` is a better project, however `node-icu-charset-detector`
+    // users the advanced libicu. As C extensions may fail by lowlevel API
+    // and env issues, we must not use libicu alone.
+    var detector;
+    try {
+        detector = require('node-icu-charset-detector');
+        return detector.detectCharset(str).toString();
+    } catch (err) {
+        detector = require("jschardet");
+        return detector.detect(str).encoding;
+    }
+};
+
+module.exports.convert = function(str, fromCharset, toCharset) {
+    try {
+        var Iconv = require('iconv').Iconv;
+        var converter = new Iconv(fromCharset, toCharset);
+        return converter.convert(str);
+    } catch (err1) {
+        try {
+            return require('child_process').spawnSync(
+              'iconv', ['-f', fromCharset, '-t', toCharset],
+              { input: str }
+            ).stdout.toString();
+        } catch (err2) {
+            return ''
+        }
+    }
+};
+
+// Handily detect the current charset and failsafe convert with '//TRANSLIT//IGNORE'
+module.exports.convertTo = function(str, toCharset) {
+    var fromCharset = this.detect(str);
+    return this.convert(str, fromCharset, toCharset + '//TRANSLIT//IGNORE');
+};

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1022,23 +1022,10 @@ Client.prototype.ctcp = function(to, type, text) {
 Client.prototype.convertEncoding = function(str) {
     var self = this, out = str;
 
-    if (self.opt.encoding) {
-        try {
-            var charsetDetector = require('node-icu-charset-detector');
-            var Iconv = require('iconv').Iconv;
-            var charset = charsetDetector.detectCharset(str);
-            var converter = new Iconv(charset.toString(), self.opt.encoding);
+    if (self.opt.encoding)
+        out = require('./encode').convertTo(str, self.opt.encoding);
 
-            out = converter.convert(str);
-        } catch (err) {
-            if (self.opt.debug) {
-                util.log('\u001b[01;31mERROR: ' + err + '\u001b[0m');
-                util.inspect({ str: str, charset: charset });
-            }
-        }
-    }
-
-    return out;
+    return out ? out : str;
 };
 // blatantly stolen from irssi's splitlong.pl. Thanks, Bjoern Krombholz!
 Client.prototype._updateMaxLineLength = function() {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   ],
   "dependencies": {
     "ansi-color": "0.2.1",
-    "irc-colors": "^1.1.0"
+    "irc-colors": "^1.1.0",
+    "jschardet": "~1.3.0"
   },
   "optionalDependencies": {
     "iconv": "~2.1.6",

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -148,34 +148,26 @@
 			"maxLineLength is as expected after 433"
 		]
 	},
-    "convert-encoding": {
-        "causesException": [
-            ":ubottu!ubottu@ubuntu/bot/ubottu MODE #ubuntu -bo *!~Brian@* ubottu\r\n",
-            "Elizabeth",
-            ":sblack1!~sblack1@unaffiliated/sblack1 NICK :sblack\r\n",
-            ":TijG!~TijG@null.1ago.be PRIVMSG #ubuntu :ThinkPad\r\n"
-        ]
+  "_splitLongLines": [
+    {
+        "input": "abcde ",
+        "maxLength": 5,
+        "result": ["abcde"]
     },
-    "_splitLongLines": [
-        {
-            "input": "abcde ",
-            "maxLength": 5,
-            "result": ["abcde"]
-        },
-        {
-            "input": "abcde",
-            "maxLength": 5,
-            "result": ["abcde"]
-        },
-        {
-            "input": "abcdefghijklmnopqrstuvwxyz",
-            "maxLength": 5,
-            "result": ["abcde", "fghij", "klmno", "pqrst", "uvwxy", "z"]
-        },
-        {
-            "input": "abc abcdef abc abcd abc",
-            "maxLength": 5,
-            "result": ["abc", "abcde", "f abc", "abcd", "abc"]
-        }
-    ]
+    {
+        "input": "abcde",
+        "maxLength": 5,
+        "result": ["abcde"]
+    },
+    {
+        "input": "abcdefghijklmnopqrstuvwxyz",
+        "maxLength": 5,
+        "result": ["abcde", "fghij", "klmno", "pqrst", "uvwxy", "z"]
+    },
+    {
+        "input": "abc abcdef abc abcd abc",
+        "maxLength": 5,
+        "result": ["abc", "abcde", "f abc", "abcd", "abc"]
+    }
+  ]
 }

--- a/test/test-convert-encoding.js
+++ b/test/test-convert-encoding.js
@@ -1,53 +1,70 @@
-var irc = require('../lib/irc');
+var encode = require('../lib/encode');
 var test = require('tape');
 var testHelpers = require('./helpers');
 var checks = testHelpers.getFixtures('convert-encoding');
-var bindTo = { opt: { encoding: 'utf-8' } };
 
-test('irc.Client.convertEncoding old', function(assert) {
-    var convertEncoding = function(str) {
-        var self = this;
+var encoded = {
+    "UTF-8": {
+      "abçdéfg": "\x61\x62\xc3\xa7\x64\xc3\xa9\x66\x67",
+      "àíàçã": "\xc3\xa0\xc3\xad\xc3\xa0\xc3\xa7\xc3\xa3"
+    },
+    "Big5": {
+      "次常用國字標準字體表": new Buffer([0xa6, 0xb8, 0xb1, 0x60, 0xa5, 0xce, 0xb0,
+      0xea, 0xa6, 0x72, 0xbc, 0xd0, 0xb7, 0xc7, 0xa6, 0x72, 0xc5, 0xe9, 0xaa, 0xed])
+    },
+    "MacCyrillic": {
+      "широко применяется": new Buffer([0xF8, 0xE8, 0xF0, 0xEE, 0xEA, 0xEE, 0x20,
+       0xEF, 0xF0, 0xE8, 0xEC, 0xE5, 0xED, 0xDF, 0xE5, 0xF2, 0xF1, 0xDF])
+    },
+    "ISO-2022-JP": {
+      "ウィキペディアはオープンコンテントの百科事典です。":
+      new Buffer([0x1b, 0x24, 0x42, 0x25, 0x26, 0x25, 0x23, 0x25, 0x2d, 0x25,
+      0x5a, 0x25, 0x47, 0x25, 0x23, 0x25, 0x22, 0x24, 0x4f, 0x25, 0x2a, 0x21,
+      0x3c, 0x25, 0x57, 0x25, 0x73, 0x25, 0x33, 0x25, 0x73, 0x25, 0x46, 0x25,
+      0x73, 0x25, 0x48, 0x24, 0x4e, 0x49, 0x34, 0x32, 0x4a, 0x3b, 0x76, 0x45,
+      0x35, 0x24, 0x47, 0x24, 0x39, 0x21, 0x23, 0x1b, 0x28, 0x42])
+    }
+};
 
-        if (self.opt.encoding) {
-            var charsetDetector = require('node-icu-charset-detector');
-            var Iconv = require('iconv').Iconv;
-            var charset = charsetDetector.detectCharset(str).toString();
-            var to = new Iconv(charset, self.opt.encoding);
-
-            return to.convert(str);
-        } else {
-            return str;
+test('irc.encode.detect', function(assert) {
+    for (charSet in encoded) {
+        for (key in encoded[charSet]) {
+            var str = encoded[charSet][key];
+            console.log(key, str, encode.detect(str));
+            assert.equal(encode.detect(str), charSet);
         }
-    }.bind(bindTo);
-
-    checks.causesException.forEach(function iterate(line) {
-        var causedException = false;
-        try {
-            convertEncoding(line);
-        } catch (e) {
-            causedException = true;
-        }
-
-        assert.equal(causedException, true, line + ' caused exception');
-    });
-
+    }
     assert.end();
 });
 
-test('irc.Client.convertEncoding', function(assert) {
-    var convertEncoding = irc.Client.prototype.convertEncoding.bind(bindTo);
-
-    checks.causesException.forEach(function iterate(line) {
-        var causedException = false;
-
-        try {
-            convertEncoding(line);
-        } catch (e) {
-            causedException = true;
+test('irc.encode.convert (two way)', function(assert) {
+    for (charSet in encoded) {
+        if (charSet!='UTF-8') for (key in encoded[charSet]) {
+            var str1 = encoded[charSet][key];
+            var str2 = encode.convert(str1, charSet, 'UTF-8');
+            var str3 = encode.convert(key, 'UTF-8', charSet);
+            assert.equal(str2, key, 'convert '+charSet+' to utf8');
+            assert.equal(str3, str1.toString(), 'convert back '+charSet);
         }
+    }
+    assert.end();
+});
 
-        assert.equal(causedException, false, line + ' didn\'t cause exception');
-    });
+test('irc.encode.convert (to unfittable charset)', function(assert) {
+    for (key in encoded.Big5) {
+        var str1 = encoded.Big5[key];
+        var str2 = encode.convert(str1, 'Big5', 'ISO-8859-15');
+        assert.equal(str2, '', 'Big5 "'+key+'" do not fit ISO-8859-15.');
+    }
+    assert.end();
+});
 
+test('irc.encode.convertTo', function(assert) {
+    for (charSet in encoded) {
+        for (key in encoded[charSet]) {
+            var out = encode.convertTo(encoded[charSet][key], 'ISO-8859-15');
+            assert.notEqual(out, '');
+        }
+    }
     assert.end();
 });


### PR DESCRIPTION
Helps the users to survive the fail of C modules, named: `iconv` and `node-icu-charset-detector`

This module also provide a handily interface to detect and convert charsets.