### PR TITLE
Bug fix: 'pm' event wouldnt always be trigged

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -522,7 +522,7 @@ function Client(server, nick, opt) {
                         self.emit('message' + to.toLowerCase(), from, text, message);
                     }
                 }
-                if (to == self.nick) self.emit('pm', from, text, message);
+                if (to.toUpperCase() === self.nick.toUpperCase()) self.emit('pm', from, text, message);
 
                 if (self.opt.debug && to == self.nick)
                     util.log('GOT MESSAGE from ' + from + ': ' + text);


### PR DESCRIPTION
Fixed case where event would not be triggered, because case-sensitivity is not checked between 2 variables.