### PR TITLE
 quit event provides wrong channel information #398

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -548,10 +548,10 @@ function Client(server, nick, opt) {
 
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    if (message.nick in channel.users && channel.users[message.nick] != "undefined" ) {
-                    delete channel.users[message.nick];
-                    channels.push(channame);
-                }
+                    if (message.nick in channel.users && channel.users[message.nick] != "undefined") {
+                        delete channel.users[message.nick];
+                        channels.push(channame);
+                    }
                 });
 
                 // who, reason, channels

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -546,11 +546,12 @@ function Client(server, nick, opt) {
 
                 channels = [];
 
-                // TODO better way of finding what channels a user is in?
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
+                    if (message.nick in channel.users && channel.users[message.nick] != "undefined" ) {
                     delete channel.users[message.nick];
                     channels.push(channame);
+                }
                 });
 
                 // who, reason, channels

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -548,7 +548,7 @@ function Client(server, nick, opt) {
 
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    if (message.nick in channel.users && typeof channel.users[message.nick] !== "undefined") {
+                    if (message.nick in channel.users && typeof channel.users[message.nick] !== 'undefined') {
                         delete channel.users[message.nick];
                         channels.push(channame);
                     }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -548,7 +548,7 @@ function Client(server, nick, opt) {
 
                 Object.keys(self.chans).forEach(function(channame) {
                     var channel = self.chans[channame];
-                    if (message.nick in channel.users && channel.users[message.nick] != "undefined") {
+                    if (message.nick in channel.users && typeof channel.users[message.nick] !== "undefined") {
                         delete channel.users[message.nick];
                         channels.push(channame);
                     }


### PR DESCRIPTION
Real users from other channels are getting mixed into all ""tracker"" object channels:
(self.chans[channame].users) they are undefined phantoms.  The way users
are added here needs rechecking.  I added a check to make sure phantom
user are not included in the channels array that is emitted through the quit event.

https://github.com/martynsmith/node-irc/issues/398