### PR TITLE
Move dependency 'ansi-color' to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     }
   ],
   "dependencies": {
-    "ansi-color": "0.2.1",
     "irc-colors": "^1.1.0"
   },
   "optionalDependencies": {
@@ -44,6 +43,7 @@
     "node-icu-charset-detector": "0.1.0"
   },
   "devDependencies": {
+    "ansi-color": "0.2.1",
     "faucet": "0.0.1",
     "jscs": "1.9.0",
     "tape": "^3.0.3"


### PR DESCRIPTION
`ansi-color` is only used for tests, so there's no need to put it into dependencies.