### PR TITLE
Add regexp for Japanese and Korean nicknames.

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,7 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^([\uAC00-\uD7AF\u3040-\u309F\u30A0-\u30FF_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];


### PR DESCRIPTION
Some IRC servers support unicode, and even for nicknames.
The message handler receives an 'undefined' sender name if its name contains unicode characters.

I tried to add all non-special unicode characters, 
but I couldn't find any better ways than adding character range manually.

Also, I wander why there is a trailing '-' inside the [] block.
Isn't '-' implies character ranges?

Sorry for some incomplete opinions.
(This is my first time doing with js:)