### PR TITLE
Adding support for command rpl_whoreply (352)

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -398,15 +398,12 @@ function Client(server, nick, opt) {
                 self.emit('whois', self._clearWhoisData(message.args[1]));
                 break;
             case 'rpl_whoreply':
-                var nick = message.args[5];
-                self._addWhoisData(nick, 'user', message.args[2]);
-                self._addWhoisData(nick, 'host', message.args[3]);
-                self._addWhoisData(nick, 'server', message.args[4]);
-                var realNameRegex = /[0-9]+\s*(.+)/g;
-                var realName = realNameRegex.exec(message.args[7])[1];
-                self._addWhoisData(nick, 'realname', realName);
+                self._addWhoisData(message.args[5], 'user', message.args[2]);
+                self._addWhoisData(message.args[5], 'host', message.args[3]);
+                self._addWhoisData(message.args[5], 'server', message.args[4]);
+                self._addWhoisData(message.args[5], 'realname', /[0-9]+\s*(.+)/g.exec(message.args[7])[1]);
                 // emit right away because rpl_endofwho doesn't contain nick
-                self.emit('whois', self._clearWhoisData(nick));
+                self.emit('whois', self._clearWhoisData(message.args[5]));
                 break;
             case 'rpl_liststart':
                 self.channellist = [];

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -397,6 +397,17 @@ function Client(server, nick, opt) {
             case 'rpl_endofwhois':
                 self.emit('whois', self._clearWhoisData(message.args[1]));
                 break;
+            case 'rpl_whoreply':
+                var nick = message.args[5];
+                self._addWhoisData(nick, 'user', message.args[2]);
+                self._addWhoisData(nick, 'host', message.args[3]);
+                self._addWhoisData(nick, 'server', message.args[4]);
+                var realNameRegex = /[0-9]+\s*(.+)/g;
+                var realName = realNameRegex.exec(message.args[7])[1];
+                self._addWhoisData(nick, 'realname', realName);
+                // emit right away because rpl_endofwho doesn't contain nick
+                self.emit('whois', self._clearWhoisData(nick));
+                break;
             case 'rpl_liststart':
                 self.channellist = [];
                 self.emit('channellist_start');


### PR DESCRIPTION
I found that this library lacks support for this command, which my ZNC bouncer seems to send me a lot.

I have implemented support for it and have tested it by using it within my own project which uses this library.

As a special case I have emitted whois information right away because the end command - rpl_endofwho lacks nick so its impossible to match it with original rpl_whoreply

Let me know what you guys think.