### PR TITLE
Add twitch-specific functionality

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -13,6 +13,21 @@ var replyFor = require('./codes');
 module.exports = function parseMessage(line, stripColors) {
     var message = {};
     var match;
+    
+    // twitch.tv-specific, twitch stuffs a bunch of useful information here
+    // need to do a client.send("CAP REQ", "twitch.tv/tags") first
+    if(line.charAt(0) == "@") {
+        var tagend = line.indexOf(" ");
+        var tag = line.slice(1, tagend);
+        line = line.slice(tagend + 1);
+        var pairs = tag.split(';');
+        var tags = {};
+        for (var i = 0; i < pairs.length; i++) {
+            var pair = pairs[i].split('=', 2);
+            tags[pair[0]] = pair[1];
+        }
+        message.tags = tags;
+    }
 
     if (stripColors) {
         line = ircColors.stripColorsAndStyle(line);


### PR DESCRIPTION
Parse Twitch-specific message metadata.

Twitch includes information such as color, name with capitalization and emote information alongside messages in a (AFAICT) non-standard way.