### PR TITLE
added a callback function onAutoConnect that fixes issue #326

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -60,7 +60,8 @@ function Client(server, nick, opt) {
           pass: '',
           ip: '',
           user: ''
-        }
+        },
+		onAutoConnect: null
     };
 
     // Features supported by the server
@@ -101,7 +102,7 @@ function Client(server, nick, opt) {
     // TODO - fail if nick or server missing
     // TODO - fail if username has a space in it
     if (self.opt.autoConnect === true) {
-        self.connect();
+        self.connect(self.opt.onAutoConnect);
     }
 
     self.addListener('raw', function(message) {


### PR DESCRIPTION
The error mentioned in the issue #326 occurs when a user is trying to send a message before we actually connect. Actually, connecting to the server is an asynchronous action, so we wait for it to finish - and notify the caller about it