### PR TITLE
ignore rpl_luserunknown and cloak messages, emit 'send' events

### DIFF
--- a/docs/API.rst
+++ b/docs/API.rst
@@ -477,6 +477,13 @@ Events
     Emitted whenever a user performs an action (e.g. `/me waves`).
     The message parameter is exactly as in the 'raw' event.
 
+.. js:data:: 'send'
+
+    `function (text) { }`
+
+    Emitted whenever the client sends a message to the server.
+    `text` is exactly what the server sees.
+
 Colors
 ------
 

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -215,6 +215,7 @@ function Client(server, nick, opt) {
             case 'rpl_localusers':
             case 'rpl_globalusers':
             case 'rpl_statsconn':
+            case '396':
                 // Random welcome crap, ignoring
                 break;
             case 'err_nicknameinuse':

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -825,6 +825,8 @@ Client.prototype.send = function(command) {
     if (this.opt.debug)
         util.log('SEND: ' + args.join(' '));
 
+    this.emit('send', args.join(' '));
+
     if (!this.conn.requestedDisconnect) {
         this.conn.write(args.join(' ') + '\r\n');
     }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -211,6 +211,7 @@ function Client(server, nick, opt) {
             case 'rpl_luserop':
             case 'rpl_luserchannels':
             case 'rpl_luserme':
+            case 'rpl_luserunknown':
             case 'rpl_localusers':
             case 'rpl_globalusers':
             case 'rpl_statsconn':


### PR DESCRIPTION
Handle (and ignore) some new message types which display scary errors otherwise.

Emit 'send' events, so they can be seen and handled by an app. Without this the only other way to see them is debug mode.
