### PR TITLE
Allow tilde in nicks

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,7 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];


### PR DESCRIPTION
Ran into an issue with the message handler returning the "from" variable (nick) as undefined. Noticed the regex does not allow the tilde characters in nicks.