### PR TITLE
Remove #blah from the example

### DIFF
--- a/example/bot.js
+++ b/example/bot.js
@@ -4,7 +4,7 @@ var irc = require('../');
 
 var bot = new irc.Client('irc.dollyfish.net.nz', 'nodebot', {
     debug: true,
-    channels: ['#blah', '#test']
+    channels: ['#test', '#othertest']
 });
 
 bot.addListener('error', function(message) {


### PR DESCRIPTION
This keeps the same behaviour for users but minimises the impact on users in the #blah channel.