### PR TITLE
Ask the server to tell us if it is sasl-capable

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -640,7 +640,11 @@ Client.prototype._connectionHandler = function() {
         this.send('WEBIRC', this.opt.webirc.pass, this.opt.userName, this.opt.webirc.host, this.opt.webirc.ip);
     }
     if (this.opt.password) {
-        this.send('PASS', this.opt.password);
+        if (this.opt.sasl) {
+            this.send('CAP REQ', 'sasl');
+        } else {
+            this.send('PASS', this.opt.password);
+        }
     }
     if (this.opt.debug)
         util.log('Sending irc NICK/USER');


### PR DESCRIPTION
I found when connecting to a server that requires sasl (in this case, a hubot running on heroku connecting to freenode, which has just enabled sasl), the code correctly handles when sasl is available but that the server doesn't volunteer this information - we have to ask for it.  This change triggers that "ask".