### PR TITLE
Fix SASL auth

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -639,7 +639,10 @@ Client.prototype._connectionHandler = function() {
     if (this.opt.webirc.ip && this.opt.webirc.pass && this.opt.webirc.host) {
         this.send('WEBIRC', this.opt.webirc.pass, this.opt.userName, this.opt.webirc.host, this.opt.webirc.ip);
     }
-    if (this.opt.password) {
+    if (this.opt.sasl) {
+        // see http://ircv3.atheme.org/extensions/sasl-3.1
+        this.send('CAP REQ', 'sasl');
+    } else if (this.opt.password) {
         this.send('PASS', this.opt.password);
     }
     if (this.opt.debug)


### PR DESCRIPTION
Currently, node-irc sends PASS before CAP REQ, causing Freenode to think the client isn't doing SASL auth. This PR omits sending PASS if `options.sasl` is `true`. Instead, the client sends `CAP REQ`, which the server should respond, `CAP ACK`, which is then handled correctly by node-irc.

I'm pretty sure this bug was introduced in https://github.com/martynsmith/node-irc/commit/c6d42625
