### PR TITLE
Make SASL work for more networks.

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -589,9 +589,8 @@ function Client(server, nick, opt) {
 
             // for sasl
             case 'CAP':
-                if (message.args[0] === '*' &&
-                     message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+                if (message.args[1] === 'ACK' &&
+                     message.args[2].trim() === 'sasl') // there can be a space after sasl
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':


### PR DESCRIPTION
snoonet.org doesn't return * as the first argument (unless that is intended as a wildcard, meaning the switch statement always has been broken for this case) and will not return 'sasl ' as was assumed but return 'sasl'.