### PR TITLE
Added link to install instructions for ICU

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ but we really recommend using [npm](http://github.com/isaacs/npm)!
 Note that as of version 0.3.8, node-irc supports character set detection using
 [icu](http://site.icu-project.org/). You'll need to install libiconv (if
 necessary; Linux systems tend to ship this in their glibc) and libicu (and its
-headers, if necessary) in order to use this feature. If you do not have these
+headers, if necessary, [install instructions](https://github.com/mooz/node-icu-charset-detector#installing-icu)) in order to use this feature. If you do not have these
 libraries or their headers installed, you will receive errors when trying to
 build these dependencies. However, node-irc will still install (assuming
 nothing else failed) and you'll be able to use it, just not the character


### PR DESCRIPTION
The node-icu-charset-detector library details installation instructions for ICU that I found helpful. Thought maybe others would find it helpful too.