### PR TITLE
fix(ping timeouts): When a ping timeout is detected properly destroy …

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -675,7 +675,7 @@ Client.prototype.connectionTimedOut = function(conn) {
         // that is most current.
         return;
     }
-    self.conn.emit('close');
+    self.end();
 };
 
 (function() {
@@ -858,16 +858,7 @@ Client.prototype.connect = function(retryCount, callback) {
         if (self.opt.debug)
             util.log('Connection got "close" event');
 
-        // If we are abandoning a connection early (perhaps via ping timeout or
-        // requested disconnect), and there is still data sent over the connection
-        // after 'close' fires, we don't want that data leaking into the client.
-        // Instead, it should be ignored, so remove the data listener.
-        self.conn.removeListener('data', handleData);
-
-        // Stop the CyclingPingTimer for debug sanity.
-        self.conn.cyclingPingTimer.stop();
-
-        if (self.conn.requestedDisconnect)
+        if (self.conn && self.conn.requestedDisconnect)
             return;
         if (self.opt.debug)
             util.log('Disconnected: reconnecting');
@@ -893,6 +884,15 @@ Client.prototype.connect = function(retryCount, callback) {
         }
     });
 };
+
+Client.prototype.end = function() {
+    if (this.conn) {
+        this.conn.cyclingPingTimer.stop();
+        this.conn.destroy();
+    }
+    this.conn = null;
+};
+
 Client.prototype.disconnect = function(message, callback) {
     if (typeof (message) === 'function') {
         callback = message;


### PR DESCRIPTION
…the existing connection before making a new one.

Previously the connection wasn't being closed properly as the the `close` event on the socket was just being emitted instead of actually closing the connection. This caused the client to open a new, duplicate connection on reconnect, instead of replacing the existing connection.