### PR TITLE
check if modeParams[mode] is undefined (issue #454)

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -291,7 +291,7 @@ function Client(server, nick, opt) {
                                 channel.modeParams[mode] = [param];
                             }
                         } else {
-                            if(typeof(channel.modeParams[mode]) != 'undefined'){
+                            if (typeof (channel.modeParams[mode]) != 'undefined') {
                                 if (arr) {
                                     channel.modeParams[mode] = channel.modeParams[mode]
                                         .filter(function(v) { return v !== param[0]; });

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -291,13 +291,15 @@ function Client(server, nick, opt) {
                                 channel.modeParams[mode] = [param];
                             }
                         } else {
-                            if (arr) {
-                                channel.modeParams[mode] = channel.modeParams[mode]
-                                    .filter(function(v) { return v !== param[0]; });
-                            }
-                            if (!arr || channel.modeParams[mode].length === 0) {
-                                channel.mode = channel.mode.replace(mode, '');
-                                delete channel.modeParams[mode];
+                            if(typeof(channel.modeParams[mode]) != 'undefined'){
+                                if (arr) {
+                                    channel.modeParams[mode] = channel.modeParams[mode]
+                                        .filter(function(v) { return v !== param[0]; });
+                                }
+                                if (!arr || channel.modeParams[mode].length === 0) {
+                                    channel.mode = channel.mode.replace(mode, '');
+                                    delete channel.modeParams[mode];
+                                }
                             }
                         }
                     };


### PR DESCRIPTION
see #454 

Not sure if this is the most elegant way of going about this, but it stops the client from crashing, which is cool.