### PR TITLE
Support for non-ASCII character nickname.

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,7 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^([^!]*)(!([^@]+)@(.*))?$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];


### PR DESCRIPTION
Related to #456 

Recently I fix the code for detect nick before '!' character.
From [this line](https://github.com/martynsmith/node-irc/blob/master/lib/parse_message.js#L26), to `match = message.prefix.match(/^([^!]*)(!([^@]+)@(.*))?$/);`

This one is very similar with #175 (by @ejnahc), because the PRs above does not catch nickname like 'Αλφαé'(non-CJK characters).
This is not strictly fit for RFC, but practically useful for non-ASCII IRC servers (NICKNAME +'!'+ IDENT +'@'+ ADDRESS).