### PR TITLE
Consistently emit errors after logging them

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -628,9 +628,8 @@ function Client(server, nick, opt) {
             // Commands relating to OPER
             case 'err_nooperhost':
                 if (self.opt.showErrors) {
+                    util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                     self.emit('error', message);
-                    if (self.opt.showErrors)
-                        util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 }
                 break;
 
@@ -640,9 +639,9 @@ function Client(server, nick, opt) {
 
             default:
                 if (message.commandType == 'error') {
-                    self.emit('error', message);
                     if (self.opt.showErrors)
                         util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
+                    self.emit('error', message);
                 }
                 else {
                     if (self.opt.debug)


### PR DESCRIPTION
When showErrors is enabled. Otherwise, showErrors will be a no-op unless you also bind an error handler.

Someone please take a look at the `err_nooperhost` case - I removed the superfluous if statement, but it wasn't evident whether the error should be emitted always, or only if `showErrors` is set.