### PR TITLE
Fixed Issue with messageSplit not being considered

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -1066,7 +1066,7 @@ Client.prototype.notice = function(target, text) {
 
 Client.prototype._speak = function(kind, target, text) {
     var self = this;
-    var maxLength = this.maxLineLength - target.length;
+    var maxLength = Math.min(this.maxLineLength - target.length, this.opt.messageSplit);
     if (typeof text !== 'undefined') {
         text.toString().split(/\r?\n/).filter(function(line) {
             return line.length > 0;


### PR DESCRIPTION
I was working on an ircbot and noticed the messageSplit option wasn't working properly. A little research shows that this code was properly fixed some ago but was somehow overridden again later with the faulty code. I went ahead and copied the working code back in and it seems to be working as intended now.