### PR TITLE
Add failing split test case

### DIFF
--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -186,6 +186,11 @@
             "input": "æøå",
             "maxLength": 5,
             "result": ["æø", "å"]
+        },
+        {
+            "input": "\u000308\u0002\u0002\u0002bold and yellow\u0002\u0003",
+            "maxLength": 12,
+            "result": ["\u000308\u0002\u0002\u0002bold", "and yellow\u0002\u0003"]
         }
     ],
 	"_splitLongLines_no_max": [

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -181,6 +181,11 @@
             "input": "æøå",
             "maxLength": 4,
             "result": ["æø", "å"]
+        },
+        {
+            "input": "æøå",
+            "maxLength": 5,
+            "result": ["æø", "å"]
         }
     ],
 	"_splitLongLines_no_max": [

--- a/test/data/fixtures.json
+++ b/test/data/fixtures.json
@@ -176,6 +176,11 @@
             "input": "abc abcdef abc abcd abc",
             "maxLength": 5,
             "result": ["abc", "abcde", "f abc", "abcd", "abc"]
+        },
+        {
+            "input": "æøå",
+            "maxLength": 4,
+            "result": ["æø", "å"]
         }
     ],
 	"_splitLongLines_no_max": [


### PR DESCRIPTION
This is a failing test case for #255. The string `æøå` is 6 bytes long when encoded as utf-8.
