### PR TITLE
Dependencies now use 'compatible' versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "irc-colors": "^1.1.0"
   },
   "optionalDependencies": {
-    "iconv": "~2.1.6",
-    "node-icu-charset-detector": "~0.1.2"
+    "iconv": "^2.1.6",
+    "node-icu-charset-detector": "^0.1.2"
   },
   "devDependencies": {
-    "ansi-color": "0.2.1",
-    "faucet": "0.0.1",
-    "jscs": "1.9.0",
+    "ansi-color": "^0.2.1",
+    "faucet": "^0.0.1",
+    "jscs": "^1.9.0",
     "tape": "^3.0.3"
   }
 }


### PR DESCRIPTION
I updated `package.json` to use 'compatible' version dependencies. I simply added a `^` before each command name.
It also fixes issue #463 