### PR TITLE
CAPabilities before nickpass

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -57,13 +57,15 @@ function Client(server, nick, opt) {
         channelPrefixes: '&#',
         messageSplit: 512,
         encoding: false,
+        capIdentifyMsg: false,
         webirc: {
           pass: '',
           ip: '',
           host: ''
         },
         millisecondsOfSilenceBeforePingSent: 15 * 1000,
-        millisecondsBeforePingTimeout: 8 * 1000
+        millisecondsBeforePingTimeout: 8 * 1000,
+        caps: []
     };
 
     // Features supported by the server
@@ -597,10 +599,15 @@ function Client(server, nick, opt) {
 
             // for sasl
             case 'CAP':
-                if (message.args[0] === '*' &&
-                     message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
-                    self.send('AUTHENTICATE', 'PLAIN');
+                if (message.args[1] === 'NAK') {
+                    self.emit('error', 'CAP ERROR for ": ' + self.CAP.join(' ') + '" CAP sent. Response:' + util.inspect(message));
+                } else if (message.args[1] === 'ACK') {
+                    if (message.args[0] === '*' && message.args[2].indexOf('sasl') !== -1) {
+                        self.send('AUTHENTICATE', 'PLAIN');
+                    } else {
+                        self.emit('cap', message);
+                    }
+                }
                 break;
             case 'AUTHENTICATE':
                 if (message.args[0] === '+') self.send('AUTHENTICATE',
@@ -714,10 +721,23 @@ Client.prototype._connectionHandler = function() {
     if (this.opt.webirc.ip && this.opt.webirc.pass && this.opt.webirc.host) {
         this.send('WEBIRC', this.opt.webirc.pass, this.opt.userName, this.opt.webirc.host, this.opt.webirc.ip);
     }
+
+    if (this.opt.capIdentifyMsg) {
+        this.opt.caps.push('identify-msg');
+    }
     if (this.opt.sasl) {
         // see http://ircv3.atheme.org/extensions/sasl-3.1
-        this.send('CAP REQ', 'sasl');
-    } else if (this.opt.password) {
+        this.opt.caps.push('sasl');
+    }
+    if (this.opt.caps.length) {
+        if (this.opt.debug)
+            util.log('Sending irc CAPS');
+
+        this.send('CAP REQ', this.opt.caps.join(' '));
+        this.send('CAP', 'END');
+    }
+
+    if (this.opt.password) {
         this.send('PASS', this.opt.password);
     }
     if (this.opt.debug)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "Chris Nehren <cnehren@pobox.com>",
     "Henri Niemeläinen <aivot-on@iki.fi>",
     "Alex Miles <ghostaldev@gmail.com>",
-    "Simmo Saan <simmo.saan@gmail.com>"
+    "Simmo Saan <simmo.saan@gmail.com>",
+    "Dariusz Niemczyk <palid@o2.pl>",
+    "Barry Carlyon <barry@barrycarlyon.co.uk>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've created a way to define server CAPs in the options passed to `new irc.Client()`.

As it's often a need to send server CAPabilities before sending Nick/Pass

Then I found conflicting PR #348 and merged that in.