### PR TITLE
Add Feature: No auto WHOIS

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -52,6 +52,7 @@ function Client(server, nick, opt) {
         certExpired: false,
         floodProtection: false,
         floodProtectionDelay: 1000,
+        nowhois: false,
         sasl: false,
         stripColors: false,
         channelPrefixes: '&#',
@@ -131,11 +132,13 @@ function Client(server, nick, opt) {
                 self.hostMask = welcomeStringWords[welcomeStringWords.length - 1];
                 self._updateMaxLineLength();
                 self.emit('registered', message);
-                self.whois(self.nick, function(args) {
-                    self.nick = args.nick;
-                    self.hostMask = args.user + '@' + args.host;
-                    self._updateMaxLineLength();
-                });
+                if (!self.opt.nowhois) {
+                    self.whois(self.nick, function(args) {
+                        self.nick = args.nick;
+                        self.hostMask = args.user + '@' + args.host;
+                        self._updateMaxLineLength();
+                    });
+                }
                 break;
             case 'rpl_myinfo':
                 self.supported.usermodes = message.args[3];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "Chris Nehren <cnehren@pobox.com>",
     "Henri Niemeläinen <aivot-on@iki.fi>",
     "Alex Miles <ghostaldev@gmail.com>",
-    "Simmo Saan <simmo.saan@gmail.com>"
+    "Simmo Saan <simmo.saan@gmail.com>",
+    "Barry Carlyon <barry@barrycarlyon.co.uk>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
If for some reason you find yourself talking to a IRC server that doesn't support WHOIS, provide a a option to disable whois on connect

`opt.nowhois: true`

Will prevent whois on connect