### PR TITLE
Emit event lastly for PART and KICK

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -499,12 +499,6 @@ function Client(server, nick, opt) {
                 }
                 break;
             case 'PART':
-                // channel, who, reason
-                self.emit('part', message.args[0], message.nick, message.args[1], message);
-                self.emit('part' + message.args[0], message.nick, message.args[1], message);
-                if (message.args[0] != message.args[0].toLowerCase()) {
-                    self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
-                }
                 if (self.nick == message.nick) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
@@ -515,16 +509,16 @@ function Client(server, nick, opt) {
                         delete channel.users[message.nick];
                     }
                 }
+
+                // channel, who, reason
+                self.emit('part', message.args[0], message.nick, message.args[1], message);
+                self.emit('part' + message.args[0], message.nick, message.args[1], message);
+                if (message.args[0] != message.args[0].toLowerCase()) {
+                    self.emit('part' + message.args[0].toLowerCase(), message.nick, message.args[1], message);
+                }
+                
                 break;
             case 'KICK':
-                // channel, who, by, reason
-                self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
-                self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
-                if (message.args[0] != message.args[0].toLowerCase()) {
-                    self.emit('kick' + message.args[0].toLowerCase(),
-                              message.args[1], message.nick, message.args[2], message);
-                }
-
                 if (self.nick == message.args[1]) {
                     channel = self.chanData(message.args[0]);
                     delete self.chans[channel.key];
@@ -535,6 +529,15 @@ function Client(server, nick, opt) {
                         delete channel.users[message.args[1]];
                     }
                 }
+
+                // channel, who, by, reason
+                self.emit('kick', message.args[0], message.args[1], message.nick, message.args[2], message);
+                self.emit('kick' + message.args[0], message.args[1], message.nick, message.args[2], message);
+                if (message.args[0] != message.args[0].toLowerCase()) {
+                    self.emit('kick' + message.args[0].toLowerCase(),
+                              message.args[1], message.nick, message.args[2], message);
+                }
+
                 break;
             case 'KILL':
                 nick = message.args[0];


### PR DESCRIPTION
In my opinion it makes more sense to emit the KICK and PART event once the client has finished updating what it needs to. 

I remember having some problems due to this when I was running a bot of mine, the biggest issue being accessing the channel's object before it was updated (within listeners for KICK and PART).