### PR TITLE
Repair error when bot whois someone who is connected via ssl 

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -420,6 +420,9 @@ function Client(server, nick, opt) {
             case 'rpl_whoisoperator':
                 self._addWhoisData(message.args[1], 'operator', message.args[2]);
                 break;
+            case '320': // reply about ssl in undernet ircu (P10 protocol)
+                 self._addWhoisData(message.args[1], 'sslinfo',message.args[1] +' '+ message.args[2]);
+                break;
             case '330': // rpl_whoisaccount?
                 self._addWhoisData(message.args[1], 'account', message.args[2]);
                 self._addWhoisData(message.args[1], 'accountinfo', message.args[3]);


### PR DESCRIPTION
error: 
`Unhandled message: { prefix: 'OGN5.OnlineGamesNet.net',
  server: 'OGN5.OnlineGamesNet.net',
  command: '320',
  rawCommand: '320',
  commandType: 'normal',
  args: [ 'lemontest', 'PyexHelp', 'is connected via SSL' ] }
`
I was added in irc.js lib case for 320 reply. 
