### PR TITLE
Update iconv to 2.2.1 and node-icu-charset-detector to 0.2.0 to fix node 6+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "irc-colors": "^1.1.0"
   },
   "optionalDependencies": {
-    "iconv": "~2.1.6",
-    "node-icu-charset-detector": "~0.1.2"
+    "iconv": "~2.2.1",
+    "node-icu-charset-detector": "~0.2.0"
   },
   "devDependencies": {
     "ansi-color": "0.2.1",


### PR DESCRIPTION
Currently building it without these updates will fail so this will hopefully fix it.