### PR TITLE
Censor password in debug output

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -930,8 +930,15 @@ Client.prototype.send = function(command) {
         args[args.length - 1] = ':' + args[args.length - 1];
     }
 
-    if (this.opt.debug)
-        util.log('SEND: ' + args.join(' '));
+    if (this.opt.debug) {
+        var line;
+        if (command === 'PASS') {
+            line = 'PASS [censored]';
+        } else {
+            line = args.join(' ');
+        }
+        util.log('SEND: ' + line);
+    }
 
     if (!this.conn.requestedDisconnect) {
         this.conn.write(args.join(' ') + '\r\n');

--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -13,6 +13,21 @@ var replyFor = require('./codes');
 module.exports = function parseMessage(line, stripColors) {
     var message = {};
     var match;
+    
+    // twitch.tv-specific, twitch stuffs a bunch of useful information here
+    // need to do a client.send("CAP REQ", "twitch.tv/tags") first
+    if(line.charAt(0) == "@") {
+        var tagend = line.indexOf(" ");
+        var tag = line.slice(1, tagend);
+        line = line.slice(tagend + 1);
+        var pairs = tag.split(';');
+        var tags = {};
+        for (var i = 0; i < pairs.length; i++) {
+            var pair = pairs[i].split('=', 2);
+            tags[pair[0]] = pair[1];
+        }
+        message.tags = tags;
+    }
 
     if (stripColors) {
         line = ircColors.stripColorsAndStyle(line);


### PR DESCRIPTION
When you're developing something that uses this IRC library, with other people watching, and using the library's debug mode, it would be nice if it does not print your IRC password in plain text into the console.

So I made a change that detects any `PASS` commands being output, and censors the output in a fairly simple manner.

I realise there can be more than one opinion about this, so obviously feel free to not merge it, but it's just a problem that I personally experienced. Thanks for a great library! :)