### PR TITLE
Censor password in debug output

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -930,8 +930,15 @@ Client.prototype.send = function(command) {
         args[args.length - 1] = ':' + args[args.length - 1];
     }
 
-    if (this.opt.debug)
-        util.log('SEND: ' + args.join(' '));
+    if (this.opt.debug) {
+        var line;
+        if (command === 'PASS') {
+            line = 'PASS [censored]';
+        } else {
+            line = args.join(' ');
+        }
+        util.log('SEND: ' + line);
+    }
 
     if (!this.conn.requestedDisconnect) {
         this.conn.write(args.join(' ') + '\r\n');


### PR DESCRIPTION
(Re-added from botched pull request #497)

When you're developing something that uses this IRC library, with other people watching, and using the library's debug mode, it would be nice if it does not print your IRC password in plain text into the console.

So I made a change that detects any `PASS` commands being output, and censors the output in a fairly simple manner.

I realise there can be more than one opinion about this, so obviously feel free to not merge it, but it's just a problem that I personally experienced. Thanks for a great library! :)