### PR TITLE
Emit unhandled

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -645,6 +645,7 @@ function Client(server, nick, opt) {
                         util.log('\u001b[01;31mERROR: ' + util.inspect(message) + '\u001b[0m');
                 }
                 else {
+                    self.emit('unhandled', message);
                     if (self.opt.debug)
                         util.log('\u001b[01;31mUnhandled message: ' + util.inspect(message) + '\u001b[0m');
                     break;


### PR DESCRIPTION
Emit 'unhandled' event, just in case you need to handle something non-standard, without having to modify the library source.

Previously discussed in #80.