### PR TITLE
check if mode is defined before using it 

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -294,7 +294,7 @@ function Client(server, nick, opt) {
                             } else {
                                 channel.modeParams[mode] = [param];
                             }
-                        } else {
+                        } else if (channel.modeParams[mode]) {
                             if (arr) {
                                 channel.modeParams[mode] = channel.modeParams[mode]
                                     .filter(function(v) { return v !== param[0]; });


### PR DESCRIPTION
if a mode change was futile, currently the library just panics and dies.
(for example, if a user who was not banned is unbanned).

instead, let's check if there's anything to this mode before trying to do
things with it.

this fixes #454