### PR TITLE
Don't crash on empty rpl_whoischannels message

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -411,7 +411,8 @@ function Client(server, nick, opt) {
                 break;
             case 'rpl_whoischannels':
                // TODO - clean this up?
-                self._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
+                var arg2 = message.args[2];
+                self._addWhoisData(message.args[1], 'channels', arg2 ? arg2.trim().split(/\s+/) : []);
                 break;
             case 'rpl_whoisserver':
                 self._addWhoisData(message.args[1], 'server', message.args[2]);


### PR DESCRIPTION
On an empty message `message.args[2]` was undefined and calling `.trim()` on that crashed. And if `message.args[2]` would have been `''` the result would be `['']`, which would have been also wrong.