### PR TITLE
Fix CAP match for some IRC daemons

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -597,9 +597,14 @@ function Client(server, nick, opt) {
 
             // for sasl
             case 'CAP':
-                if (message.args[0] === '*' &&
-                     message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+                // if we are debug, log output from the server
+                if (self.opt.debug) {
+                    util.log(message.args[0] + '-')
+                    util.log(message.args[1] + '-')
+                    util.log(message.args[2] + '-')
+                }
+                if (message.args[1] === 'ACK' &&
+                    message.args[2] === 'sasl')
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "Chris Nehren <cnehren@pobox.com>",
     "Henri Niemeläinen <aivot-on@iki.fi>",
     "Alex Miles <ghostaldev@gmail.com>",
-    "Simmo Saan <simmo.saan@gmail.com>"
+    "Simmo Saan <simmo.saan@gmail.com>",
+    "Nick Silkey <nick@silkey.org>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some IRC daemons such as InspIRCd return an random string after a
client's CAP REQ request.  This would fail to match and block SASL
AUTHENTICATEs.  Also the space after `sasl` would also block the above
AUTHENTICATEs.

This change:

* allows for emitting that output in logs via debug in config
* stops matching on said field which can be an irrelevant moving
target
* removes the trailing space for the mentioned sasl field

Example InspIRCd output:

```bash
$ openssl s_client -connect irc.corp.com:6697
...
CAP REQ :sasl
:irc.corp.com CAP 354AAUXBK ACK :sasl
^C
$ openssl s_client -connect irc.corp.com:6697
...
CAP REQ :sasl
:irc.corp.com CAP 354AAUXC8 ACK :sasl
^C
```