### PR TITLE
Get EventEmitter correctly

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -21,7 +21,7 @@ exports.Client = Client;
 var net  = require('net');
 var tls  = require('tls');
 var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('events');
 
 var colors = require('./colors');
 var parseMessage = require('./parse_message');


### PR DESCRIPTION
`atom-irc` is [erroring out](https://github.com/cjsaylor/atom-irc/issues/33) currently at this line:

```js
util.inherits(Client, EventEmitter);
```

> TypeError: The super constructor to "inherits" must not be null or undefined

The [documentation for `inherits`](https://nodejs.org/api/util.html#util_util_inherits_constructor_superconstructor) says that the "super constructor" is the second parameter, so this error implies that `EventEmitter` is null or undefined. I checked [the documentation](https://nodejs.org/api/events.html), and it says:

```js
const EventEmitter = require('events');
```

But `node-irc` currently does this instead:

```js
var EventEmitter = require('events').EventEmitter;
```

If I remove the trailing `.EventEmitter` as in this pull request, the error in `atom-irc` is resolved.