### PR TITLE
Fix parsing of non-latin nicks

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,13 +23,18 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^(.*)!.*$/);
+
         if (match) {
             message.nick = match[1];
+        }
+
+        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+
+        if (match) {
             message.user = match[3];
             message.host = match[4];
-        }
-        else {
+        }  else {
             message.server = message.prefix;
         }
     }


### PR DESCRIPTION
Hi,

I found an issue when some event are occurring with a user whose nick consists from non Latin characters, it cannot be parsed and as a result it is undefined in such event like "join".

Here is a possible solution