### PR TITLE
Resolv 'push' of undefined error when calling client.list()

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -440,6 +440,7 @@ function Client(server, nick, opt) {
                 self.emit('channellist_start');
                 break;
             case 'rpl_list':
+                self.channellist = [];
                 channel = {
                     name: message.args[1],
                     users: message.args[2],


### PR DESCRIPTION
Resolve the following error when using the command `client.list()`:

```javascript
node_modules/irc/lib/irc.js:849
                        throw err;
                        ^
TypeError: Cannot read property 'push' of undefined
    at Client.<anonymous> (/[...]/node_modules/irc/lib/irc.js:449:33)
```