### PR TITLE
allow / in nicknames

### DIFF
--- a/lib/parse_message.js
+++ b/lib/parse_message.js
@@ -23,7 +23,7 @@ module.exports = function parseMessage(line, stripColors) {
     if (match) {
         message.prefix = match[1];
         line = line.replace(/^:[^ ]+ +/, '');
-        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/);
+        match = message.prefix.match(/^([_a-zA-Z0-9\~\[\]\\\/`^{}|-]*)(!([^@]+)@(.*))?$/);
         if (match) {
             message.nick = match[1];
             message.user = match[3];


### PR DESCRIPTION
This closes bug #526 allowing /'s in nicknames which fixes undefined nicks on pylinked networks.