### PR TITLE
Update irc.js for SASL auth against inspircd/anope

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -599,7 +599,8 @@ function Client(server, nick, opt) {
             case 'CAP':
                 if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+//                   message.args[2] === 'sasl ') // there's a space after sasl
+                     message.args[2].startsWith('sasl') ) // there is at least one case with *NO* space after sasl
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':


### PR DESCRIPTION
As is, SASL authentication fails against InspIRCd 3.10.0 & Anope 2.0.9 (FreeBSD). Checking the arguments in the CAP message, arg 2 presents as 'sasl' without a trailing space. In this particular case, removing the space allows successful authentication. Checking that the string.startsWith('sasl') presumably handles both cases without introducing much risk. [Alternatively, we can check against both strings explicitly.]