### PR TITLE
SASL Doesn't work on Libera

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -599,7 +599,7 @@ function Client(server, nick, opt) {
             case 'CAP':
                 if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+                     message.args[2].startsWith('sasl')) // there's a space after sasl
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':


### PR DESCRIPTION
Trying to use SASL when connecting to libera didn't work. There's no space after sasl so AUTHENTICATE never gets sent and then the client disconnects.

Maybe that some servers add this space, so I used `startsWith` instead to account for either. 