### PR TITLE
Fix SASL on libera.chat

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -599,7 +599,7 @@ function Client(server, nick, opt) {
             case 'CAP':
                 if (message.args[0] === '*' &&
                      message.args[1] === 'ACK' &&
-                     message.args[2] === 'sasl ') // there's a space after sasl
+                     message.args[2].trim() === 'sasl') // there's a space after sasl
                     self.send('AUTHENTICATE', 'PLAIN');
                 break;
             case 'AUTHENTICATE':


### PR DESCRIPTION
While deploying an IRC bot to libera.chat (w/@lartu) we were unable to connect via SASL because the ACK was never recognized. 

The reason for that rested on a check that expected a weird leftover space character.

This PR checks that a trimmed version of the third argument is equal to `sasl`.

This is enough for our personal purposes but i'm not sure if it is a proper fix.